### PR TITLE
Ability to show configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Usage of cleaner:
         list clusters with the same rule(s) disabled by different users
   -output string
         filename for old cluster listing
+  -show-configuration
+        show configuration
   -summary
         print summary table after cleanup
   -version

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -28,7 +28,7 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-if ! gocyclo -over 12 -avg .
+if ! gocyclo -over 13 -avg .
 then
     echo -e "${RED_BG}[FAIL]${NC} Functions/methods with high cyclomatic complexity detected"
     exit 1


### PR DESCRIPTION
# Description

New command line flag to display actual configuration.

Fixes #107

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
