### PR TITLE
Refactor: use `CliFlags` data type

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -228,7 +228,7 @@ func PrintSummaryTable(summary Summary) {
 
 // doSelectedOperation function performs selected operation: check data
 // retention, cleanup selected data, or fill-id database by test data
-func doSelectedOperation(config ConfigStruct, connection *sql.DB, cliFlags CliFlags) error {
+func doSelectedOperation(configuration ConfigStruct, connection *sql.DB, cliFlags CliFlags) error {
 	switch {
 	case cliFlags.ShowVersion:
 		fmt.Println(version)
@@ -237,11 +237,13 @@ func doSelectedOperation(config ConfigStruct, connection *sql.DB, cliFlags CliFl
 		fmt.Println(authors)
 		return nil
 	case cliFlags.ShowConfiguration:
-		showConfiguration(config)
+		showConfiguration(configuration)
 		return nil
 	case cliFlags.PerformCleanup:
 		// cleanup operation
-		clusterList, improperClusterCounter, err := readClusterList(config.Cleaner.ClusterListFile, cliFlags.Clusters)
+		clusterList, improperClusterCounter, err := readClusterList(
+			configuration.Cleaner.ClusterListFile,
+			cliFlags.Clusters)
 		if err != nil {
 			log.Err(err).Msg("Read cluster list")
 			return err
@@ -279,7 +281,8 @@ func doSelectedOperation(config ConfigStruct, connection *sql.DB, cliFlags CliFl
 		return nil
 	default:
 		// display old records in database
-		err := displayAllOldRecords(connection, config.Cleaner.MaxAge, cliFlags.Output)
+		err := displayAllOldRecords(connection,
+			configuration.Cleaner.MaxAge, cliFlags.Output)
 		if err != nil {
 			log.Err(err).Msg(selectingRecordsFromDatabase)
 			return err

--- a/types.go
+++ b/types.go
@@ -43,3 +43,17 @@ type Summary struct {
 	ImproperClusterEntries int
 	DeletionsForTable      map[string]int
 }
+
+// CliFlags represents structure holding all command line arguments and flags.
+type CliFlags struct {
+	ShowVersion               bool
+	ShowAuthors               bool
+	ShowConfiguration         bool
+	PrintSummaryTable         bool
+	Output                    string
+	PerformCleanup            bool
+	DetectMultipleRuleDisable bool
+	FillInDatabase            bool
+	MaxAge                    string
+	Clusters                  string
+}


### PR DESCRIPTION
# Description

Refactor: use `ClifFags` data type

Fixes #119

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
