### PR TITLE
[CCXDEV-7402] Fix random cpu limit on stage

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -20,6 +20,7 @@ objects:
         schedule: ${JOB_SCHEDULE}
         restartPolicy: Never
         concurrencyPolicy: Forbid
+        activeDeadlineSeconds: 600
         podSpec:
           image: ${IMAGE}:${IMAGE_TAG}
           resources:


### PR DESCRIPTION
# Description

In stage env our completed cronjobs are counted into the CPU/mem quota. To not count the cronjobs into the quota, we need to use activeDeadlineSeconds for cronjobs to not count the completed jobs into quota.

The activeDeadlineSeconds stops a pod after the specified timeout if it does not complete earlier.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
