### PR TITLE
improve unit test code coverage for storage.go to 77%

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -29,11 +29,18 @@ package main
 // https://medium.com/@robiplus/golang-trick-export-for-test-aa16cbd7b8cd
 // to see why this trick is needed.
 var (
+	TablesAndKeys = tablesAndKeys
+
 	// functions from the storage.go source file
 	ReadOrgID                         = readOrgID
+	DisplayMultipleRuleDisable        = displayMultipleRuleDisable
+	DisplayAllOldRecords              = displayAllOldRecords
 	PerformDisplayMultipleRuleDisable = performDisplayMultipleRuleDisable
 	PerformListOfOldReports           = performListOfOldReports
 	DeleteRecordFromTable             = deleteRecordFromTable
+	PerformCleanupInDB                = performCleanupInDB
+	PerformVacuumDB                   = performVacuumDB
+	FillInDatabaseByTestData          = fillInDatabaseByTestData
 
 	// functions from the ccx_notification_writer.go source file
 	ShowVersion         = showVersion

--- a/storage.go
+++ b/storage.go
@@ -106,7 +106,7 @@ func initDatabaseConnection(configuration StorageConfiguration) (*sql.DB, error)
 // multiple users have disabled some rules.
 func displayMultipleRuleDisable(connection *sql.DB, output string) error {
 	var fout *os.File = nil
-	writer := bufio.NewWriter(os.Stdout)
+	var writer *bufio.Writer = nil
 
 	if output != "" {
 		// create output file
@@ -264,7 +264,7 @@ func readOrgID(connection *sql.DB, clusterName string) (int, error) {
 // older than the specified time duration. Those records are simply displayed.
 func displayAllOldRecords(connection *sql.DB, maxAge, output string) error {
 	var fout *os.File = nil
-	writer := bufio.NewWriter(os.Stdout)
+	var writer *bufio.Writer = nil
 
 	if output != "" {
 		// create output file

--- a/storage.go
+++ b/storage.go
@@ -106,7 +106,7 @@ func initDatabaseConnection(configuration StorageConfiguration) (*sql.DB, error)
 // multiple users have disabled some rules.
 func displayMultipleRuleDisable(connection *sql.DB, output string) error {
 	var fout *os.File = nil
-	var writer *bufio.Writer = nil
+	writer := bufio.NewWriter(os.Stdout)
 
 	if output != "" {
 		// create output file
@@ -117,7 +117,6 @@ func displayMultipleRuleDisable(connection *sql.DB, output string) error {
 		}
 		// an object used to write to file
 		writer = bufio.NewWriter(fout)
-
 	}
 
 	defer func() {
@@ -265,7 +264,7 @@ func readOrgID(connection *sql.DB, clusterName string) (int, error) {
 // older than the specified time duration. Those records are simply displayed.
 func displayAllOldRecords(connection *sql.DB, maxAge, output string) error {
 	var fout *os.File = nil
-	var writer *bufio.Writer = nil
+	writer := bufio.NewWriter(os.Stdout)
 
 	if output != "" {
 		// create output file

--- a/storage_test.go
+++ b/storage_test.go
@@ -21,6 +21,7 @@ package main_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -241,6 +242,179 @@ func TestPerformDisplayMultipleRuleDisableOnError(t *testing.T) {
 	}
 }
 
+// TestPerformDisplayMultipleRuleDisableResults checks the basic behaviour of
+// performDisplayMultipleRuleDisable function with results returned.
+func TestPerformDisplayMultipleRuleDisableResults(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	// prepare mocked result for SQL query
+	rows1 := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
+	rows1.AddRow("123e4567-e89b-12d3-a456-426614173998", "rule.test|KEY", 1)
+
+	// expected query performed by tested function
+	expectedQuery1 := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_rule_toggle group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
+	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows1)
+
+	// prepare mocked result for SQL query
+	rows2 := sqlmock.NewRows([]string{"org_id"})
+	rows2.AddRow(42)
+
+	// expected query performed by tested function
+	expectedQuery2 := "select org_id from report where cluster = \\$1"
+	mock.ExpectQuery(expectedQuery2).WillReturnRows(rows2)
+	mock.ExpectClose()
+
+	// first query to be performed
+	query1 := `
+                select cluster_id, rule_id, count(*) as cnt
+                  from cluster_rule_toggle
+                 group by cluster_id, rule_id
+                having count(*)>1
+                 order by cnt desc;
+`
+	// call the tested function
+	err = cleaner.PerformDisplayMultipleRuleDisable(connection, nil, query1, "cluster_rule_toggle")
+	if err != nil {
+		t.Errorf("error was not expected while updating stats: %s", err)
+	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestDisplayMultipleRuleDisableResultsStringOutput checks the basic behaviour of
+// displayMultipleRuleDisable function with results returned, printing to std out.
+func TestDisplayMultipleRuleDisableResultsStringOutput(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	// prepare mocked result for SQL query
+	toggleRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
+	toggleRows.AddRow("123e4567-e89b-12d3-a456-426614173998", "rule.test|KEY", 1)
+
+	// expected query performed by tested function
+	toggleQuery := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_rule_toggle group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
+	mock.ExpectQuery(toggleQuery).WillReturnRows(toggleRows)
+
+	// prepare mocked org_id query result for SQL query
+	orgIDRows := sqlmock.NewRows([]string{"org_id"})
+	orgIDRows.AddRow(1)
+
+	// expected query performed by tested function
+	orgIDQuery := "select org_id from report where cluster = \\$1"
+	mock.ExpectQuery(orgIDQuery).WillReturnRows(orgIDRows)
+
+	// prepare mocked result for SQL query
+	feedbackRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
+	feedbackRows.AddRow("123e4567-e89b-12d3-a456-426614173998", "rule.test|KEY", 1)
+
+	// expected query performed by tested function
+	feedbackQuery := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_user_rule_disable_feedback group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
+	mock.ExpectQuery(feedbackQuery).WillReturnRows(feedbackRows)
+
+	// prepare mocked org_id query result for SQL query
+	orgIDRows2 := sqlmock.NewRows([]string{"org_id"})
+	orgIDRows2.AddRow(1)
+
+	// expected query performed by tested function
+	orgIDQuery2 := "select org_id from report where cluster = \\$1"
+	mock.ExpectQuery(orgIDQuery2).WillReturnRows(orgIDRows2)
+	// another org_id query
+	mock.ExpectClose()
+
+	// call the tested function without filename (stdout)
+	err = cleaner.DisplayMultipleRuleDisable(connection, "")
+	if err != nil {
+		t.Errorf("error was not expected while updating stats: %s", err)
+	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestDisplayMultipleRuleDisableResultsFileError checks the basic behaviour of
+// displayMultipleRuleDisable function with results returned, printing to std out.
+func TestDisplayMultipleRuleDisableResultsFileError(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	// prepare mocked result for SQL query
+	toggleRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
+	toggleRows.AddRow("123e4567-e89b-12d3-a456-426614173998", "rule.test|KEY", 1)
+
+	// expected query performed by tested function
+	toggleQuery := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_rule_toggle group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
+	mock.ExpectQuery(toggleQuery).WillReturnRows(toggleRows)
+
+	// prepare mocked org_id query result for SQL query
+	orgIDRows := sqlmock.NewRows([]string{"org_id"})
+	orgIDRows.AddRow(1)
+
+	// expected query performed by tested function
+	orgIDQuery := "select org_id from report where cluster = \\$1"
+	mock.ExpectQuery(orgIDQuery).WillReturnRows(orgIDRows)
+
+	// prepare mocked result for SQL query
+	feedbackRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
+	feedbackRows.AddRow("123e4567-e89b-12d3-a456-426614173998", "rule.test|KEY", 1)
+
+	// expected query performed by tested function
+	feedbackQuery := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_user_rule_disable_feedback group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
+	mock.ExpectQuery(feedbackQuery).WillReturnRows(feedbackRows)
+
+	// prepare mocked org_id query result for SQL query
+	orgIDRows2 := sqlmock.NewRows([]string{"org_id"})
+	orgIDRows2.AddRow(1)
+
+	// expected query performed by tested function
+	orgIDQuery2 := "select org_id from report where cluster = \\$1"
+	mock.ExpectQuery(orgIDQuery2).WillReturnRows(orgIDRows2)
+	// another org_id query
+	mock.ExpectClose()
+
+	// call the tested function with invalid filename
+	err = cleaner.DisplayMultipleRuleDisable(connection, "/")
+	if err != nil {
+		t.Errorf("error was not expected while updating stats: %s", err)
+	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
 // TestPerformListOfOldReportsNoResults checks the basic behaviour of
 // performListOfOldReports function.
 func TestPerformListOfOldReportsNoResults(t *testing.T) {
@@ -298,6 +472,82 @@ func TestPerformListOfOldReportsResults(t *testing.T) {
 
 	// call the tested function
 	err = cleaner.PerformListOfOldReports(connection, "10", nil)
+	if err != nil {
+		t.Errorf("error was not expected while updating stats: %s", err)
+	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestDisplayAllOldRecordsWithWriter checks the basic behaviour of
+// displayAllOldRecords function.
+func TestDisplayAllOldRecordsWithWriter(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
+	reportedAt := time.Now()
+	updatedAt := time.Now()
+	rows.AddRow("123e4567-e89b-12d3-a456-426614173998", reportedAt, updatedAt)
+
+	// expected query performed by tested function
+	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// call the tested function without filename (stdout)
+	err = cleaner.DisplayAllOldRecords(connection, "10", "")
+	if err != nil {
+		t.Errorf("error was not expected while updating stats: %s", err)
+	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestDisplayAllOldRecordsWithFileError checks the basic behaviour of
+// displayAllOldRecords function with file error
+func TestDisplayAllOldRecordsWithFileError(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	// prepare mocked result for SQL query
+	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
+	reportedAt := time.Now()
+	updatedAt := time.Now()
+	rows.AddRow("123e4567-e89b-12d3-a456-426614173998", reportedAt, updatedAt)
+
+	// expected query performed by tested function
+	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	mock.ExpectClose()
+
+	// call the tested function with invalid filename ("/")
+	err = cleaner.DisplayAllOldRecords(connection, "10", "/")
 	if err != nil {
 		t.Errorf("error was not expected while updating stats: %s", err)
 	}
@@ -423,6 +673,131 @@ func TestDeleteRecordFromTableOnError(t *testing.T) {
 	if err != mockedError {
 		t.Errorf("different error was returned: %v", err)
 	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestPerformVacuumDB checks the basic behaviour of
+// PerformVacuumDB function.
+func TestPerformVacuumDB(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	// expected query performed by tested function
+	expectedExec := "DELETE FROM table_x WHERE key_x = \\$"
+	mock.ExpectExec(expectedExec).WithArgs("key_value").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	expectedVacuum := "VACUUM VERBOSE;"
+	mock.ExpectExec(expectedVacuum).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectClose()
+
+	// call the tested function
+	affected, err := cleaner.DeleteRecordFromTable(connection, "table_x", "key_x", "key_value")
+	if err != nil {
+		t.Errorf("error was not expected while updating stats: %s", err)
+	}
+
+	// test number of affected rows
+	if affected != 1 {
+		t.Errorf("wrong number of rows affected: %d", affected)
+	}
+
+	err = cleaner.PerformVacuumDB(connection)
+	if err != nil {
+		t.Errorf("error was not expected: %s", err)
+	}
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestFillInDatabaseByTestData checks the basic behaviour of
+// fillInDatabaseByTestData function.
+func TestFillInDatabaseByTestData(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	clusterNames := [...]string{
+		"00000000-0000-0000-0000-000000000000",
+		"11111111-1111-1111-1111-111111111111",
+		"5d5892d4-1f74-4ccf-91af-548dfc9767aa",
+	}
+
+	for _, clusterName := range clusterNames {
+		mock.ExpectExec("INSERT INTO report").WithArgs(clusterName).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("INSERT INTO cluster_rule_toggle").WithArgs(clusterName).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("INSERT INTO cluster_rule_user_feedback").WithArgs(clusterName).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("INSERT INTO cluster_user_rule_disable_feedback").WithArgs(clusterName).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("INSERT INTO rule_hit").WithArgs(clusterName).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	}
+
+	mock.ExpectClose()
+
+	err = cleaner.FillInDatabaseByTestData(connection)
+
+	err = connection.Close()
+	if err != nil {
+		t.Fatalf("error during closing connection: %v", err)
+	}
+
+	// check if all expectations were met
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+// TestPerformCleanupInDB checks the basic behaviour of
+// performCleanupInDB function.
+func TestPerformCleanupInDB(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	clusterNames := cleaner.ClusterList{
+		"00000000-0000-0000-0000-000000000000",
+		"11111111-1111-1111-1111-111111111111",
+		"5d5892d4-1f74-4ccf-91af-548dfc9767aa",
+	}
+
+	for _, clusterName := range clusterNames {
+		for _, tableAndKey := range cleaner.TablesAndKeys {
+			// expected query performed by tested function
+			expectedExec := fmt.Sprintf("DELETE FROM %v WHERE %v = \\$", tableAndKey.TableName, tableAndKey.KeyName)
+			mock.ExpectExec(expectedExec).WithArgs(clusterName).WillReturnResult(sqlmock.NewResult(1, 2))
+		}
+	}
+
+	mock.ExpectClose()
+
+	_, err = cleaner.PerformCleanupInDB(connection, clusterNames)
 
 	err = connection.Close()
 	if err != nil {

--- a/storage_test.go
+++ b/storage_test.go
@@ -759,6 +759,9 @@ func TestFillInDatabaseByTestData(t *testing.T) {
 	mock.ExpectClose()
 
 	err = cleaner.FillInDatabaseByTestData(connection)
+	if err != nil {
+		t.Errorf("error was not expected: %s", err)
+	}
 
 	err = connection.Close()
 	if err != nil {
@@ -798,6 +801,9 @@ func TestPerformCleanupInDB(t *testing.T) {
 	mock.ExpectClose()
 
 	_, err = cleaner.PerformCleanupInDB(connection, clusterNames)
+	if err != nil {
+		t.Errorf("error was not expected: %s", err)
+	}
 
 	err = connection.Close()
 	if err != nil {

--- a/storage_test.go
+++ b/storage_test.go
@@ -75,9 +75,7 @@ func expectOrgIDQuery(mock sqlmock.Sqlmock) {
 func TestReadOrgIDNoResults(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{})
@@ -89,9 +87,7 @@ func TestReadOrgIDNoResults(t *testing.T) {
 
 	// call the tested function
 	org_id, err := cleaner.ReadOrgID(connection, "123e4567-e89b-12d3-a456-426614174000")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check the org ID returned from tested function
 	if org_id != -1 {
@@ -109,18 +105,14 @@ func TestReadOrgIDNoResults(t *testing.T) {
 func TestReadOrgIDResult(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	expectOrgIDQuery(mock)
 
 	// call the tested function
 	org_id, err := cleaner.ReadOrgID(connection, "123e4567-e89b-12d3-a456-426614174000")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check the org ID returned from tested function
 	if org_id != defaultOrgID {
@@ -141,9 +133,7 @@ func TestReadOrgIDOnError(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedQuery := "select org_id from report where cluster = \\$1"
@@ -178,9 +168,7 @@ func TestReadOrgIDOnError(t *testing.T) {
 func TestPerformDisplayMultipleRuleDisableNoResults(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{})
@@ -200,9 +188,7 @@ func TestPerformDisplayMultipleRuleDisableNoResults(t *testing.T) {
 `
 	// call the tested function
 	err = cleaner.PerformDisplayMultipleRuleDisable(connection, nil, query1, "cluster_rule_toggle")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -219,9 +205,7 @@ func TestPerformDisplayMultipleRuleDisableOnError(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedQuery := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_rule_toggle group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
@@ -259,9 +243,7 @@ func TestPerformDisplayMultipleRuleDisableOnError(t *testing.T) {
 func TestPerformDisplayMultipleRuleDisableOnScanError(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows1 := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
@@ -301,9 +283,7 @@ func TestPerformDisplayMultipleRuleDisableOnScanError(t *testing.T) {
 func TestPerformDisplayMultipleRuleDisableResults(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows1 := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
@@ -328,9 +308,7 @@ func TestPerformDisplayMultipleRuleDisableResults(t *testing.T) {
 `
 	// call the tested function
 	err = cleaner.PerformDisplayMultipleRuleDisable(connection, nil, query1, "cluster_rule_toggle")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -344,9 +322,7 @@ func TestPerformDisplayMultipleRuleDisableResults(t *testing.T) {
 func TestDisplayMultipleRuleDisableResultsScanError(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	toggleRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
@@ -378,9 +354,7 @@ func TestDisplayMultipleRuleDisableOnError(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	toggleQuery := "select cluster_id, rule_id, count\\(\\*\\) as cnt from cluster_rule_toggle group by cluster_id, rule_id having count\\(\\*\\)>1 order by cnt desc;"
@@ -412,9 +386,7 @@ func TestDisplayMultipleRuleDisableOnError(t *testing.T) {
 func TestDisplayMultipleRuleDisableResultsNoOutput(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	toggleRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
@@ -443,9 +415,7 @@ func TestDisplayMultipleRuleDisableResultsNoOutput(t *testing.T) {
 
 	// call the tested function without filename (only printed in logs)
 	err = cleaner.DisplayMultipleRuleDisable(connection, "")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -462,9 +432,7 @@ func TestDisplayMultipleRuleDisableResultsFileOutput(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	toggleRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
@@ -493,9 +461,7 @@ func TestDisplayMultipleRuleDisableResultsFileOutput(t *testing.T) {
 
 	// call the tested function with filename
 	err = cleaner.DisplayMultipleRuleDisable(connection, outFile)
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -545,9 +511,7 @@ func TestDisplayMultipleRuleDisableResultsFileOutput(t *testing.T) {
 func TestDisplayMultipleRuleDisableResultsFileError(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 	// prepare mocked result for SQL query
 	toggleRows := sqlmock.NewRows([]string{"cluster_id", "rule_id", "cnt"})
 	toggleRows.AddRow(cluster1ID, rule1ID, 1)
@@ -574,9 +538,7 @@ func TestDisplayMultipleRuleDisableResultsFileError(t *testing.T) {
 
 	// call the tested function with invalid filename
 	err = cleaner.DisplayMultipleRuleDisable(connection, "/")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -590,9 +552,7 @@ func TestDisplayMultipleRuleDisableResultsFileError(t *testing.T) {
 func TestPerformListOfOldReportsNoResults(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{})
@@ -604,9 +564,7 @@ func TestPerformListOfOldReportsNoResults(t *testing.T) {
 
 	// call the tested function
 	err = cleaner.PerformListOfOldReports(connection, "10", nil)
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -620,9 +578,7 @@ func TestPerformListOfOldReportsNoResults(t *testing.T) {
 func TestPerformListOfOldReportsResults(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
@@ -637,9 +593,7 @@ func TestPerformListOfOldReportsResults(t *testing.T) {
 
 	// call the tested function
 	err = cleaner.PerformListOfOldReports(connection, "10", nil)
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -653,9 +607,7 @@ func TestPerformListOfOldReportsResults(t *testing.T) {
 func TestPerformListOfOldScanError(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
@@ -687,9 +639,7 @@ func TestPerformListOfOldDBError(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
@@ -716,9 +666,7 @@ func TestPerformListOfOldDBError(t *testing.T) {
 func TestDisplayAllOldRecordsNoOutput(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
@@ -733,9 +681,7 @@ func TestDisplayAllOldRecordsNoOutput(t *testing.T) {
 
 	// call the tested function without filename (stdout)
 	err = cleaner.DisplayAllOldRecords(connection, "10", "")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -751,9 +697,7 @@ func TestDisplayAllOldRecordsFileOutput(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
@@ -769,9 +713,7 @@ func TestDisplayAllOldRecordsFileOutput(t *testing.T) {
 
 	// call the tested function without filename (stdout)
 	err = cleaner.DisplayAllOldRecords(connection, "10", outFile)
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -821,9 +763,7 @@ func TestDisplayAllOldRecordsFileOutput(t *testing.T) {
 func TestDisplayAllOldRecordsWithFileError(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// prepare mocked result for SQL query
 	rows := sqlmock.NewRows([]string{"cluster", "reported_at", "last_checked"})
@@ -838,9 +778,7 @@ func TestDisplayAllOldRecordsWithFileError(t *testing.T) {
 
 	// call the tested function with invalid filename ("/")
 	err = cleaner.DisplayAllOldRecords(connection, "10", "/")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -857,9 +795,7 @@ func TestPerformListOfOldReportsOnError(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
@@ -889,9 +825,7 @@ func TestPerformListOfOldReportsOnError(t *testing.T) {
 func TestDeleteRecordFromTable(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedExec := "DELETE FROM table_x WHERE key_x = \\$"
@@ -900,9 +834,7 @@ func TestDeleteRecordFromTable(t *testing.T) {
 
 	// call the tested function
 	affected, err := cleaner.DeleteRecordFromTable(connection, "table_x", "key_x", "key_value")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// test number of affected rows
 	if affected != 1 {
@@ -924,9 +856,7 @@ func TestDeleteRecordFromTableOnError(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedExec := "DELETE FROM table_x WHERE key_x = \\$"
@@ -961,9 +891,7 @@ func TestDeleteRecordFromTableOnError(t *testing.T) {
 func TestPerformVacuumDB(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
 	expectedExec := "DELETE FROM table_x WHERE key_x = \\$"
@@ -976,9 +904,7 @@ func TestPerformVacuumDB(t *testing.T) {
 
 	// call the tested function
 	affected, err := cleaner.DeleteRecordFromTable(connection, "table_x", "key_x", "key_value")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// test number of affected rows
 	if affected != 1 {
@@ -986,9 +912,7 @@ func TestPerformVacuumDB(t *testing.T) {
 	}
 
 	err = cleaner.PerformVacuumDB(connection)
-	if err != nil {
-		t.Errorf("error was not expected: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -1002,9 +926,7 @@ func TestPerformVacuumDB(t *testing.T) {
 func TestFillInDatabaseByTestData(t *testing.T) {
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	clusterNames := [...]string{
 		"00000000-0000-0000-0000-000000000000",
@@ -1023,9 +945,7 @@ func TestFillInDatabaseByTestData(t *testing.T) {
 	mock.ExpectClose()
 
 	err = cleaner.FillInDatabaseByTestData(connection)
-	if err != nil {
-		t.Errorf("error was not expected: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check if DB can be closed successfully
 	checkConnectionClose(t, connection)
@@ -1041,9 +961,7 @@ func TestPerformCleanupInDB(t *testing.T) {
 
 	// prepare new mocked connection to database
 	connection, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "error creating SQL mock")
 
 	clusterNames := cleaner.ClusterList{
 		"00000000-0000-0000-0000-000000000000",
@@ -1065,9 +983,7 @@ func TestPerformCleanupInDB(t *testing.T) {
 	mock.ExpectClose()
 
 	deletedRows, err := cleaner.PerformCleanupInDB(connection, clusterNames)
-	if err != nil {
-		t.Errorf("error was not expected: %s", err)
-	}
+	assert.NoError(t, err, "error not expected while calling tested function")
 
 	// check tables have correct number of deleted rows for each table
 	for tableName, deletedRowCount := range deletedRows {

--- a/storage_test.go
+++ b/storage_test.go
@@ -533,7 +533,7 @@ func TestDisplayMultipleRuleDisableResultsFileOutput(t *testing.T) {
 	assert.Equal(t, ruleFeedbackLine[2], rule1ID)
 	assert.Equal(t, ruleFeedbackLine[3], "1")
 
-	outputFile.Close()
+	err = outputFile.Close()
 	assert.NoError(t, err)
 	// delete test file from filesystem
 	err = os.Remove(outFile)
@@ -809,7 +809,7 @@ func TestDisplayAllOldRecordsFileOutput(t *testing.T) {
 	assert.Equal(t, line2[2], updatedAt.Format(time.RFC3339))
 	assert.Equal(t, line2[3], "1")
 
-	outputFile.Close()
+	err = outputFile.Close()
 	assert.NoError(t, err)
 	// delete test file from filesystem
 	err = os.Remove(outFile)


### PR DESCRIPTION
# Description
only missing function in storage.go is about initializing a database

overall percentage 26% -> 50%

Fixes 

## Type of change

Please delete options that are not relevant.

- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
