### PR TITLE
Increase GitHub CI timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
+          args: --timeout=3m
           # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.


### PR DESCRIPTION
# Description

Increase GitHub CI timeout

## Type of change

- Configuration update

## Testing steps

To be checked on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
