### PR TITLE
Attempt to fix pr_check.sh syntax failure

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -exv
 
 # --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------
 APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
+REF_ENV="insights-production"
 COMPONENT_NAME="insights-aggregator-cleaner"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/insights-results-aggregator-cleaner"
 COMPONENTS="ccx-insights-results insights-aggregator-cleaner"  # space-separated list of components to laod
 COMPONENTS_W_RESOURCES="insights-aggregator-cleaner"  # component to keep
-CACHE_FROM_LATEST_IMAGE="false"
+CACHE_FROM_LATEST_IMAGE="true"
 
 export IQE_PLUGINS="ccx"
 export IQE_MARKER_EXPRESSION=""
@@ -17,6 +33,7 @@ export IQE_FILTER_EXPRESSION="test_plugin_accessible"
 export IQE_REQUIREMENTS_PRIORITY=""
 export IQE_TEST_IMPORTANCE=""
 export IQE_CJI_TIMEOUT="30m"
+export IQE_ENV="ephemeral"
 
 
 function build_image() {
@@ -28,8 +45,10 @@ function deploy_ephemeral() {
 }
 
 function run_smoke_tests() {
-    source $CICD_ROOT/cji_smoke_test.sh
-    source $CICD_ROOT/post_test_results.sh  # publish results in Ibutsu
+   # component name needs to be re-export to match ClowdApp name (as bonfire requires for this)
+   export COMPONENT_NAME="ccx-insights-results-aggregator-cleaner"
+   source $CICD_ROOT/cji_smoke_test.sh
+   source $CICD_ROOT/post_test_results.sh  # publish results in Ibutsu
 }
 
 


### PR DESCRIPTION
# Description

Fix/debug failure like this:
```
15:12:15 Login Succeeded
15:12:15 ++ docker login '-u=****' -p=**** registry.redhat.io
15:12:15 WARNING! Using --password via the CLI is insecure. Use --password-stdin.
15:12:16 WARNING! Your password will be stored unencrypted in /var/lib/jenkins/workspace/RedHatInsights-insights-results-aggregator-cleaner-pr-check/.docker/config.json.
15:12:16 Configure a credential helper to remove this warning. See
15:12:16 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
15:12:16 
15:12:16 Login Succeeded
15:12:16 ++ set +x
15:12:16 checking if image 'quay.io/cloudservices/insights-results-aggregator-cleaner:pr-214-1f9ba30' already exists in quay.io...
15:12:17 parse error: Invalid numeric literal at line 1, column 7
15:12:17 Build step 'Execute shell' marked build as failure
```

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
