### PR TITLE
Sync with newer database schema

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -63,6 +63,15 @@ const (
 	writeToFileMsg = "Write to file"
 )
 
+// SQL commands
+const (
+	selectOldReports = `
+	    SELECT cluster, reported_at, last_checked_at
+	      FROM report
+	     WHERE reported_at < NOW() - $1::INTERVAL
+	     ORDER BY reported_at`
+)
+
 // initDatabaseConnection initializes driver, checks if it's supported and
 // initializes connection to the storage.
 func initDatabaseConnection(configuration *StorageConfiguration) (*sql.DB, error) {
@@ -304,8 +313,7 @@ func displayAllOldRecords(connection *sql.DB, maxAge, output string) error {
 // performListOfOldReports read and displays old records read from reported_at
 // table
 func performListOfOldReports(connection *sql.DB, maxAge string, writer *bufio.Writer) error {
-	query := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW() - $1::INTERVAL ORDER BY reported_at"
-	rows, err := connection.Query(query, maxAge)
+	rows, err := connection.Query(selectOldReports, maxAge)
 	if err != nil {
 		return err
 	}

--- a/storage.go
+++ b/storage.go
@@ -399,6 +399,10 @@ var tablesAndKeys = [...]TableAndKey{
 		TableName: "recommendation",
 		KeyName:   "cluster_id",
 	},
+	{
+		TableName: "report_info",
+		KeyName:   "cluster_id",
+	},
 	// must be at the end due to constraints
 	{
 		TableName: "report",

--- a/storage.go
+++ b/storage.go
@@ -462,7 +462,7 @@ func performListOfOldRatings(connection *sql.DB, maxAge string) error {
 					Str("error key", errorKey).
 					Int("rating", rating).
 					Str("updated at", lastUpdatedAtF).
-					Int("age", age).
+					Int("rating age", age).
 					Msg("Old Advisor rating")
 				count++
 			}
@@ -515,7 +515,7 @@ func performListOfOldConsumerErrors(connection *sql.DB, maxAge string) error {
 					Str("key", key).
 					Str("message", message).
 					Str("consumed", consumedF).
-					Int("age", age).
+					Int("error age", age).
 					Msg("Old consumer error")
 				count++
 			}

--- a/storage.go
+++ b/storage.go
@@ -343,175 +343,184 @@ func displayAllOldRecords(connection *sql.DB, maxAge, output string) error {
 	return nil
 }
 
-// performListOfOldReports read and displays old records read from reported_at
-// table
-func performListOfOldReports(connection *sql.DB, maxAge string, writer *bufio.Writer) error {
-	log.Info().Msg("List of old reports begin")
-	rows, err := connection.Query(selectOldReports, maxAge)
+func listOldDatabaseRecords(connection *sql.DB, maxAge string,
+	writer *bufio.Writer, query string,
+	logEntry string, countLogEntry string,
+	callback func(rows *sql.Rows, writer *bufio.Writer) (int, error)) error {
+
+	log.Info().Msg(logEntry + " begin")
+	rows, err := connection.Query(query, maxAge)
 	if err != nil {
 		return err
 	}
 
-	// used to compute a real record age
-	now := time.Now()
-
-	// reports count
-	count := 0
-
-	// iterate over all old records
-	for rows.Next() {
-		var (
-			clusterName string
-			reported    time.Time
-			lastChecked time.Time
-		)
-
-		// read one old record from the report table
-		if err := rows.Scan(&clusterName, &reported, &lastChecked); err != nil {
-			// close the result set in case of any error
-			if closeErr := rows.Close(); closeErr != nil {
-				log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
-			}
-			return err
-		}
-
-		// compute the real record age
-		age := int(math.Ceil(now.Sub(reported).Hours() / 24)) // in days
-
-		// prepare for the report
-		reportedF := reported.Format(time.RFC3339)
-		lastCheckedF := lastChecked.Format(time.RFC3339)
-
-		// just print the report
-		log.Info().Str(clusterNameMsg, clusterName).
-			Str("reported", reportedF).
-			Str("lastChecked", lastCheckedF).
-			Int("age", age).
-			Msg("Old report")
-
-		if writer != nil {
-			_, err := fmt.Fprintf(writer, "%s,%s,%s,%d\n", clusterName, reportedF, lastCheckedF, age)
-			if err != nil {
-				log.Error().Err(err).Msg(writeToFileMsg)
-			}
-		}
-		count++
+	count, err := callback(rows, writer)
+	if err != nil {
+		log.Error().Err(err).Msg("Query error")
+		return err
 	}
-	log.Info().Int("reports count", count).Msg("List of old reports end")
+
+	log.Info().Int(countLogEntry, count).Msg(logEntry + " end")
 	return nil
+}
+
+// performListOfOldReports read and displays old records read from reported_at
+// table
+func performListOfOldReports(connection *sql.DB, maxAge string, writer *bufio.Writer) error {
+	return listOldDatabaseRecords(connection, maxAge, writer, selectOldReports, "List of old reports", "reports count",
+		func(rows *sql.Rows, writer *bufio.Writer) (int, error) {
+			// used to compute a real record age
+			now := time.Now()
+
+			// reports count
+			count := 0
+
+			// iterate over all old records
+			for rows.Next() {
+				var (
+					clusterName string
+					reported    time.Time
+					lastChecked time.Time
+				)
+
+				// read one old record from the report table
+				if err := rows.Scan(&clusterName, &reported, &lastChecked); err != nil {
+					// close the result set in case of any error
+					if closeErr := rows.Close(); closeErr != nil {
+						log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
+					}
+					return count, err
+				}
+
+				// compute the real record age
+				age := int(math.Ceil(now.Sub(reported).Hours() / 24)) // in days
+
+				// prepare for the report
+				reportedF := reported.Format(time.RFC3339)
+				lastCheckedF := lastChecked.Format(time.RFC3339)
+
+				// just print the report
+				log.Info().Str(clusterNameMsg, clusterName).
+					Str("reported", reportedF).
+					Str("lastChecked", lastCheckedF).
+					Int("age", age).
+					Msg("Old report")
+
+				if writer != nil {
+					_, err := fmt.Fprintf(writer, "%s,%s,%s,%d\n", clusterName, reportedF, lastCheckedF, age)
+					if err != nil {
+						log.Error().Err(err).Msg(writeToFileMsg)
+					}
+				}
+				count++
+			}
+			return count, nil
+		})
 }
 
 // performListOfOldRatings read and displays old Advisor ratings read from
 // advisor_ratings table
 func performListOfOldRatings(connection *sql.DB, maxAge string) error {
-	log.Info().Msg("List of old Advisor ratings begin")
-	rows, err := connection.Query(selectOldAdvisorRatings, maxAge)
-	if err != nil {
-		return err
-	}
+	return listOldDatabaseRecords(connection, maxAge, nil, selectOldAdvisorRatings, "List of old Advisor ratings", "ratings count",
+		func(rows *sql.Rows, writer *bufio.Writer) (int, error) {
+			// used to compute a real record age
+			now := time.Now()
 
-	// used to compute a real record age
-	now := time.Now()
+			// reports count
+			count := 0
 
-	// reports count
-	count := 0
+			// iterate over all old records
+			for rows.Next() {
+				var (
+					orgID         string
+					ruleFQDN      string
+					errorKey      string
+					ruleID        string
+					rating        int
+					lastUpdatedAt time.Time
+				)
 
-	// iterate over all old records
-	for rows.Next() {
-		var (
-			orgID         string
-			ruleFQDN      string
-			errorKey      string
-			ruleID        string
-			rating        int
-			lastUpdatedAt time.Time
-		)
+				// read one old record from the report table
+				if err := rows.Scan(&orgID, &ruleFQDN, &errorKey, &ruleID, &rating, &lastUpdatedAt); err != nil {
+					// close the result set in case of any error
+					if closeErr := rows.Close(); closeErr != nil {
+						log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
+					}
+					return count, err
+				}
 
-		// read one old record from the report table
-		if err := rows.Scan(&orgID, &ruleFQDN, &errorKey, &ruleID, &rating, &lastUpdatedAt); err != nil {
-			// close the result set in case of any error
-			if closeErr := rows.Close(); closeErr != nil {
-				log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
+				// compute the real error age
+				age := int(math.Ceil(now.Sub(lastUpdatedAt).Hours() / 24)) // in days
+
+				// prepare for the report
+				lastUpdatedAtF := lastUpdatedAt.Format(time.RFC3339)
+
+				// just print the report
+				log.Info().
+					Str("organization", orgID).
+					Str("rule FQDN", ruleFQDN).
+					Str("error key", errorKey).
+					Int("rating", rating).
+					Str("updated at", lastUpdatedAtF).
+					Int("age", age).
+					Msg("Old Advisor rating")
+				count++
 			}
-			return err
-		}
-
-		// compute the real error age
-		age := int(math.Ceil(now.Sub(lastUpdatedAt).Hours() / 24)) // in days
-
-		// prepare for the report
-		lastUpdatedAtF := lastUpdatedAt.Format(time.RFC3339)
-
-		// just print the report
-		log.Info().
-			Str("organization", orgID).
-			Str("rule FQDN", ruleFQDN).
-			Str("error key", errorKey).
-			Int("rating", rating).
-			Str("updated at", lastUpdatedAtF).
-			Int("age", age).
-			Msg("Old Advisor rating")
-		count++
-	}
-	log.Info().Int("ratings count", count).Msg("List of old Advisor ratings end")
-	return nil
+			return count, nil
+		})
 }
 
 // performListOfOldConsumerErrors read and displays consumer errors stored in
 // consumer_errors table
 func performListOfOldConsumerErrors(connection *sql.DB, maxAge string) error {
-	log.Info().Msg("List of old consumer errors begin")
-	rows, err := connection.Query(selectOldConsumerErrors, maxAge)
-	if err != nil {
-		return err
-	}
+	return listOldDatabaseRecords(connection, maxAge, nil, selectOldConsumerErrors, "List of old consumer errors", "errors count",
+		func(rows *sql.Rows, writer *bufio.Writer) (int, error) {
+			// used to compute a real record age
+			now := time.Now()
 
-	// used to compute a real record age
-	now := time.Now()
+			// reports count
+			count := 0
 
-	// reports count
-	count := 0
+			// iterate over all old records
+			for rows.Next() {
+				var (
+					topic      string
+					partition  int
+					offset     int
+					key        string
+					consumedAt time.Time
+					message    string
+				)
 
-	// iterate over all old records
-	for rows.Next() {
-		var (
-			topic      string
-			partition  int
-			offset     int
-			key        string
-			consumedAt time.Time
-			message    string
-		)
+				// read one old record from the report table
+				if err := rows.Scan(&topic, &partition, &offset, &key, &consumedAt, &message); err != nil {
+					// close the result set in case of any error
+					if closeErr := rows.Close(); closeErr != nil {
+						log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
+					}
+					return count, err
+				}
 
-		// read one old record from the report table
-		if err := rows.Scan(&topic, &partition, &offset, &key, &consumedAt, &message); err != nil {
-			// close the result set in case of any error
-			if closeErr := rows.Close(); closeErr != nil {
-				log.Error().Err(closeErr).Msg(unableToCloseDBRowsHandle)
+				// compute the real error age
+				age := int(math.Ceil(now.Sub(consumedAt).Hours() / 24)) // in days
+
+				// prepare for the report
+				consumedF := consumedAt.Format(time.RFC3339)
+
+				// just print the report
+				log.Info().
+					Str("topic", topic).
+					Int("partition", partition).
+					Int("offset", offset).
+					Str("key", key).
+					Str("message", message).
+					Str("consumed", consumedF).
+					Int("age", age).
+					Msg("Old consumer error")
+				count++
 			}
-			return err
-		}
-
-		// compute the real error age
-		age := int(math.Ceil(now.Sub(consumedAt).Hours() / 24)) // in days
-
-		// prepare for the report
-		consumedF := consumedAt.Format(time.RFC3339)
-
-		// just print the report
-		log.Info().
-			Str("topic", topic).
-			Int("partition", partition).
-			Int("offset", offset).
-			Str("key", key).
-			Str("message", message).
-			Str("consumed", consumedF).
-			Int("age", age).
-			Msg("Old consumer error")
-		count++
-	}
-	log.Info().Int("errors count", count).Msg("List of old consumer errors end")
-	return nil
+			return count, nil
+		})
 }
 
 // deleteRecordFromTable function deletes selected records (identified by

--- a/storage.go
+++ b/storage.go
@@ -313,6 +313,7 @@ func displayAllOldRecords(connection *sql.DB, maxAge, output string) error {
 // performListOfOldReports read and displays old records read from reported_at
 // table
 func performListOfOldReports(connection *sql.DB, maxAge string, writer *bufio.Writer) error {
+	log.Info().Msg("List of old reports begin")
 	rows, err := connection.Query(selectOldReports, maxAge)
 	if err != nil {
 		return err
@@ -320,6 +321,9 @@ func performListOfOldReports(connection *sql.DB, maxAge string, writer *bufio.Wr
 
 	// used to compute a real record age
 	now := time.Now()
+
+	// reports count
+	count := 0
 
 	// iterate over all old records
 	for rows.Next() {
@@ -358,7 +362,9 @@ func performListOfOldReports(connection *sql.DB, maxAge string, writer *bufio.Wr
 				log.Error().Err(err).Msg(writeToFileMsg)
 			}
 		}
+		count++
 	}
+	log.Info().Int("reports count", count).Msg("List of old reports end")
 	return nil
 }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 Red Hat, Inc.
+Copyright © 2021, 2022, 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -674,9 +674,16 @@ func TestDisplayAllOldRecordsNoOutput(t *testing.T) {
 	updatedAt := time.Now()
 	rows.AddRow(cluster1ID, reportedAt, updatedAt)
 
-	// expected query performed by tested function
-	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
-	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	// expected queries performed by tested function
+	expectedQuery1 := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
+
+	expectedQuery2 := "SELECT org_id, rule_fqdn, error_key, rule_id, rating, last_updated_at FROM advisor_ratings WHERE last_updated_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY last_updated_at"
+	mock.ExpectQuery(expectedQuery2).WillReturnRows(rows)
+
+	expectedQuery3 := "SELECT topic, partition, topic_offset, key, consumed_at, message FROM consumer_error WHERE consumed_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY consumed_at"
+	mock.ExpectQuery(expectedQuery3).WillReturnRows(rows)
+
 	mock.ExpectClose()
 
 	// call the tested function without filename (stdout)
@@ -706,9 +713,16 @@ func TestDisplayAllOldRecordsFileOutput(t *testing.T) {
 	rows.AddRow(cluster1ID, reportedAt, updatedAt)
 	rows.AddRow(cluster2ID, reportedAt, updatedAt)
 
-	// expected query performed by tested function
-	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
-	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	// expected queries performed by tested function
+	expectedQuery1 := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
+
+	expectedQuery2 := "SELECT org_id, rule_fqdn, error_key, rule_id, rating, last_updated_at FROM advisor_ratings WHERE last_updated_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY last_updated_at"
+	mock.ExpectQuery(expectedQuery2).WillReturnRows(rows)
+
+	expectedQuery3 := "SELECT topic, partition, topic_offset, key, consumed_at, message FROM consumer_error WHERE consumed_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY consumed_at"
+	mock.ExpectQuery(expectedQuery3).WillReturnRows(rows)
+
 	mock.ExpectClose()
 
 	// call the tested function without filename (stdout)
@@ -771,9 +785,16 @@ func TestDisplayAllOldRecordsWithFileError(t *testing.T) {
 	updatedAt := time.Now()
 	rows.AddRow(cluster1ID, reportedAt, updatedAt)
 
-	// expected query performed by tested function
-	expectedQuery := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
-	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
+	// expected queries performed by tested function
+	expectedQuery1 := "SELECT cluster, reported_at, last_checked_at FROM report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
+
+	expectedQuery2 := "SELECT org_id, rule_fqdn, error_key, rule_id, rating, last_updated_at FROM advisor_ratings WHERE last_updated_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY last_updated_at"
+	mock.ExpectQuery(expectedQuery2).WillReturnRows(rows)
+
+	expectedQuery3 := "SELECT topic, partition, topic_offset, key, consumed_at, message FROM consumer_error WHERE consumed_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY consumed_at"
+	mock.ExpectQuery(expectedQuery3).WillReturnRows(rows)
+
 	mock.ExpectClose()
 
 	// call the tested function with invalid filename ("/")


### PR DESCRIPTION
# Description

1. Sync with newer database schema
1. Ability to display old Advisor records
1. Ability to display old consumer errors
1. Unit tests updated as needed

# An example of output

```
7:57AM DBG Started
7:57AM INF DB connection configuration driverName=postgres
7:57AM INF List of old reports begin
7:57AM INF Old report age=427 cluster=5d5892d3-1f74-4ccf-91af-548dfc9767aa lastChecked=2020-04-02T09:00:05Z reported=2022-04-27T08:53:00Z
7:57AM INF Old report age=427 cluster=6d5892d3-1f74-4ccf-91af-548dfc9767aa lastChecked=2020-04-02T09:00:05Z reported=2022-04-27T08:54:36Z
7:57AM INF Old report age=427 cluster=7d5892d3-1f74-4ccf-91af-548dfc9767aa lastChecked=2020-04-02T09:00:05Z reported=2022-04-27T08:56:20Z
7:57AM INF Old report age=427 cluster=8d5892d3-1f74-4ccf-91af-548dfc9767aa lastChecked=2020-04-02T09:00:05Z reported=2022-04-27T08:56:34Z
7:57AM INF Old report age=427 cluster=9d5892d3-1f74-4ccf-91af-548dfc9767ac lastChecked=2020-04-02T09:00:05Z reported=2022-04-27T08:56:41Z
7:57AM INF List of old reports end reports count=5
7:57AM INF List of old Advisor ratings begin
7:57AM INF List of old Advisor ratings end ratings count=0
7:57AM INF List of old consumer errors begin
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=10 offset=100 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=11 offset=101 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=12 offset=102 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=13 offset=103 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=10 offset=104 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=11 offset=105 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=20 offset=106 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=20 offset=107 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=20 offset=108 partition=1 topic=test-topic
7:57AM INF Old consumer error age=1275 consumed=2020-01-01T00:00:00Z key=20 offset=109 partition=1 topic=test-topic
7:57AM INF List of old consumer errors end errors count=10
7:57AM DBG Finished
```

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
