### PR TITLE
Only report new issues in golangci-lint github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,7 +33,7 @@ jobs:
             --timeout=3m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the action will use pre-installed Go.
           # skip-go-installation: true


### PR DESCRIPTION
# Description

Enable an option in golangci-lint so it only fails if new issues are detected (if not, CI wouldn't pass)

Fixes CCXDEV-12518

## Type of change

- CI configuration

## Testing steps

CI should pass

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
