### PR TITLE
[CCXDEV-12955] Add target to clean up all the old records, no matter the cluster ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,12 @@ Usage of cleaner:
         show authors
   -cleanup
         perform database cleanup
+  -cleanup-all
+        perform database cleanup for all old clusters
   -clusters string
-        list of clusters to cleanup
+        list of clusters to cleanup. Ignored when cleanup-all is selected
+  -dry-run
+        if true, the cleanup-all method won't delete any row, just print how many are affected (default true)
   -fill-in-db
         fill-in database by test data
   -max-age string

--- a/README.md
+++ b/README.md
@@ -12,38 +12,39 @@
 
 <!-- vim-markdown-toc GFM -->
 
-* [Description](#description)
-* [Documentation](#documentation)
-* [Contribution](#contribution)
-* [Start the service](#start-the-service)
-    * [Default operation](#default-operation)
-    * [Data cleanup](#data-cleanup)
-    * [Test data generation](#test-data-generation)
-    * [Exit status](#exit-status)
-    * [Building](#building)
-    * [Makefile targets](#makefile-targets)
-    * [Configuration](#configuration)
-* [BDD tests](#bdd-tests)
-* [Usage](#usage)
-        * [Output example](#output-example)
-* [Database structure](#database-structure)
-    * [Database schema `ocp_recommendations`](#database-schema-ocp_recommendations)
-        * [Table `report`](#table-report)
-        * [Table `cluster_rule_toggle`](#table-cluster_rule_toggle)
-        * [Table `cluster_rule_user_feedback`](#table-cluster_rule_user_feedback)
-        * [Table `cluster_user_rule_disable_feedback`](#table-cluster_user_rule_disable_feedback)
-        * [Table `consumer_error`](#table-consumer_error)
-        * [Table `migration_info `](#table-migration_info-)
-        * [Table `rule_hit`](#table-rule_hit)
-        * [Table `recommendation`](#table-recommendation)
-        * [Database tables affected by this service](#database-tables-affected-by-this-service)
-    * [Database schema `dvo_recommendations`](#database-schema-dvo_recommendations)
-        * [Table `dvo_report`](#table-dvo_report)
-* [Documentation](#documentation-1)
-    * [Documentation for source files from this repository](#documentation-for-source-files-from-this-repository)
-    * [Documentation for unit tests from this repository](#documentation-for-unit-tests-from-this-repository)
-* [Contribution](#contribution-1)
-* [Package manifest](#package-manifest)
+- [insights-results-aggregator-cleaner](#insights-results-aggregator-cleaner)
+  - [Description](#description)
+  - [Documentation](#documentation)
+  - [Contribution](#contribution)
+  - [Start the service](#start-the-service)
+    - [Default operation](#default-operation)
+    - [Data cleanup](#data-cleanup)
+    - [Test data generation](#test-data-generation)
+    - [Exit status](#exit-status)
+    - [Building](#building)
+    - [Makefile targets](#makefile-targets)
+    - [Configuration](#configuration)
+  - [BDD tests](#bdd-tests)
+  - [Usage](#usage)
+      - [Output example](#output-example)
+  - [Database structure](#database-structure)
+    - [Database schema `ocp_recommendations`](#database-schema-ocp_recommendations)
+      - [Table `report`](#table-report)
+      - [Table `cluster_rule_toggle`](#table-cluster_rule_toggle)
+      - [Table `cluster_rule_user_feedback`](#table-cluster_rule_user_feedback)
+      - [Table `cluster_user_rule_disable_feedback`](#table-cluster_user_rule_disable_feedback)
+      - [Table `consumer_error`](#table-consumer_error)
+      - [Table `migration_info `](#table-migration_info-)
+      - [Table `rule_hit`](#table-rule_hit)
+      - [Table `recommendation`](#table-recommendation)
+      - [Database tables affected by this service](#database-tables-affected-by-this-service)
+    - [Database schema `dvo_recommendations`](#database-schema-dvo_recommendations)
+      - [Table `dvo_report`](#table-dvo_report)
+  - [Documentation](#documentation-1)
+    - [Documentation for source files from this repository](#documentation-for-source-files-from-this-repository)
+    - [Documentation for unit tests from this repository](#documentation-for-unit-tests-from-this-repository)
+  - [Contribution](#contribution-1)
+  - [Package manifest](#package-manifest)
 
 <!-- vim-markdown-toc -->
 
@@ -115,10 +116,16 @@ deleted.
 Optionally it is possible to specify list of clusters to be cleaned up by using
 the `clusters ...` command line option.
 
+If you run `-cleanup-all` there is no need to use `cluster_list.txt` or 
+the `clusters` option. It will delete all the records older than `-max-age`.
+
 ### Test data generation
 
 Command line option `-fill-in-db` can be used to insert some test data into
 database. Don't use it on production, of course.
+
+You can run and initialize a database by running `podman-compose up -d`. Then
+you will be able to run `./insights-results-aggregator-cleaner -fill-in-db`.
 
 ### Exit status
 

--- a/cleaner.go
+++ b/cleaner.go
@@ -303,7 +303,7 @@ func cleanup(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags,
 
 // cleanup function starts the cleanup-all operation
 func cleanupAll(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags, schema string) (int, error) {
-	deletionsForTable, err := performCleanupAllInDB(connection, schema, configuration.Cleaner.MaxAge)
+	deletionsForTable, err := performCleanupAllInDB(connection, schema, configuration.Cleaner.MaxAge, cliFlags.DryRun)
 	if err != nil {
 		log.Err(err).Msg("Performing cleanup-all")
 		return ExitStatusPerformCleanupError, err
@@ -399,6 +399,7 @@ func main() {
 	// define and parse all command line options
 	flag.BoolVar(&cliFlags.PerformCleanup, "cleanup", false, "perform database cleanup")
 	flag.BoolVar(&cliFlags.PerformCleanupAll, "cleanup-all", false, "perform database cleanup for all old clusters")
+	flag.BoolVar(&cliFlags.DryRun, "dry-run", true, "if true, the cleanup-all method won't delete any row, just print how many are affected")
 	flag.BoolVar(&cliFlags.PrintSummaryTable, "summary", false, "print summary table after cleanup")
 	flag.BoolVar(&cliFlags.DetectMultipleRuleDisable, "multiple-rule-disable", false, "list clusters with the same rule(s) disabled by different users")
 	flag.BoolVar(&cliFlags.FillInDatabase, "fill-in-db", false, "fill-in database by test data")

--- a/cleaner.go
+++ b/cleaner.go
@@ -404,6 +404,7 @@ func main() {
 	err = CheckConfiguration(&config)
 	if err != nil {
 		log.Err(err).Msg("Check configuration")
+		return
 	}
 
 	if config.Logging.Debug {

--- a/cleaner.go
+++ b/cleaner.go
@@ -301,6 +301,21 @@ func cleanup(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags,
 	return ExitStatusOK, nil
 }
 
+// cleanup function starts the cleanup-all operation
+func cleanupAll(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags, schema string) (int, error) {
+	deletionsForTable, err := performCleanupAllInDB(connection, schema, configuration.Cleaner.MaxAge)
+	if err != nil {
+		log.Err(err).Msg("Performing cleanup")
+		return ExitStatusPerformCleanupError, err
+	}
+	if cliFlags.PrintSummaryTable {
+		var summary Summary
+		summary.DeletionsForTable = deletionsForTable
+		PrintSummaryTable(summary)
+	}
+	return ExitStatusOK, nil
+}
+
 // detectMultipleRuleDisable function detects clusters that have the same
 // rule(s) disabled by different users
 func detectMultipleRuleDisable(connection *sql.DB, cliFlags CliFlags) (int, error) {
@@ -363,6 +378,8 @@ func doSelectedOperation(configuration *ConfigStruct, connection *sql.DB, cliFla
 		return ExitStatusOK, nil
 	case cliFlags.VacuumDatabase:
 		return vacuumDB(connection)
+	case cliFlags.PerformCleanupAll:
+		return cleanupAll(configuration, connection, cliFlags, configuration.Storage.Schema)
 	case cliFlags.PerformCleanup:
 		return cleanup(configuration, connection, cliFlags, configuration.Storage.Schema)
 	case cliFlags.DetectMultipleRuleDisable:
@@ -381,6 +398,7 @@ func main() {
 
 	// define and parse all command line options
 	flag.BoolVar(&cliFlags.PerformCleanup, "cleanup", false, "perform database cleanup")
+	flag.BoolVar(&cliFlags.PerformCleanupAll, "cleanup-all", false, "perform database cleanup for all old clusters")
 	flag.BoolVar(&cliFlags.PrintSummaryTable, "summary", false, "print summary table after cleanup")
 	flag.BoolVar(&cliFlags.DetectMultipleRuleDisable, "multiple-rule-disable", false, "list clusters with the same rule(s) disabled by different users")
 	flag.BoolVar(&cliFlags.FillInDatabase, "fill-in-db", false, "fill-in database by test data")
@@ -389,7 +407,7 @@ func main() {
 	flag.BoolVar(&cliFlags.ShowAuthors, "authors", false, "show authors")
 	flag.BoolVar(&cliFlags.VacuumDatabase, "vacuum", false, "vacuum database")
 	flag.StringVar(&cliFlags.MaxAge, "max-age", "", "max age for displaying old records")
-	flag.StringVar(&cliFlags.Clusters, "clusters", "", "list of clusters to cleanup")
+	flag.StringVar(&cliFlags.Clusters, "clusters", "", "list of clusters to cleanup. Ignored when cleanup-all is selected")
 	flag.StringVar(&cliFlags.Output, "output", "", "filename for old cluster listing")
 
 	// parse all command line flags

--- a/cleaner.go
+++ b/cleaner.go
@@ -305,7 +305,7 @@ func cleanup(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags,
 func cleanupAll(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags, schema string) (int, error) {
 	deletionsForTable, err := performCleanupAllInDB(connection, schema, configuration.Cleaner.MaxAge)
 	if err != nil {
-		log.Err(err).Msg("Performing cleanup")
+		log.Err(err).Msg("Performing cleanup-all")
 		return ExitStatusPerformCleanupError, err
 	}
 	if cliFlags.PrintSummaryTable {

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -1036,6 +1036,68 @@ func TestCleanupCheckSummaryTableContent(t *testing.T) {
 	assert.Equal(t, status, main.ExitStatusOK)
 }
 
+// TestCleanupAll check the function cleanupAll when
+// summary table should not be printed
+func TestCleanupAll(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, _, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
+
+	// stub for structures needed to call the tested function
+	configuration := main.ConfigStruct{}
+
+	configuration.Cleaner = main.CleanerConfiguration{
+		MaxAge: "3 days",
+	}
+
+	cliFlags := main.CliFlags{
+		ShowVersion:       false,
+		ShowAuthors:       false,
+		ShowConfiguration: false,
+		PrintSummaryTable: false,
+	}
+
+	// call the tested function
+	status, err := main.CleanupAll(&configuration, connection, cliFlags, main.DBSchemaOCPRecommendations)
+
+	// error is not expected
+	assert.NoError(t, err, "error is not expected while calling main.cleanupAll")
+
+	// check the status
+	assert.Equal(t, status, main.ExitStatusOK)
+}
+
+// TestCleanupAllMissingMaxAge check the function cleanup fails if no MaxAge
+// is specified
+func TestCleanupAllMissingMaxAge(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, _, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
+
+	// stub for structures needed to call the tested function
+	configuration := main.ConfigStruct{}
+
+	configuration.Cleaner = main.CleanerConfiguration{
+		MaxAge: "",
+	}
+
+	cliFlags := main.CliFlags{
+		ShowVersion:       false,
+		ShowAuthors:       false,
+		ShowConfiguration: false,
+		PrintSummaryTable: false,
+	}
+
+	// call the tested function
+	status, err := main.CleanupAll(&configuration, connection, cliFlags, main.DBSchemaOCPRecommendations)
+
+	// error is not expected
+	assert.EqualError(t, err, main.MaxAgeMissing)
+
+	// check the status
+	assert.Equal(t, status, main.ExitStatusPerformCleanupError)
+}
+
 // TestDetectMultipleRuleDisable check the function detectMultipleRuleDisable when the
 // connection to DB is not established
 func TestDetectMultipleRuleDisable(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -266,7 +266,7 @@ func allSupportedDrivers() StringSet {
 // schemas
 func allSupportedSchemas() StringSet {
 	var schemas = make(StringSet)
-	schemas["ocm_recommendations"] = struct{}{}
+	schemas["ocp_recommendations"] = struct{}{}
 	schemas["dvo_recommendations"] = struct{}{}
 	return schemas
 }

--- a/config_test.go
+++ b/config_test.go
@@ -188,7 +188,7 @@ func TestCheckConfigurationPositiveTestCases(t *testing.T) {
 	config1 := main.ConfigStruct{
 		Storage: main.StorageConfiguration{
 			Driver: "postgres",
-			Schema: "ocm_recommendations",
+			Schema: "ocp_recommendations",
 		},
 	}
 	err := main.CheckConfiguration(&config1)
@@ -209,7 +209,7 @@ func TestCheckConfigurationNegativeTestCases(t *testing.T) {
 	config1 := main.ConfigStruct{
 		Storage: main.StorageConfiguration{
 			Driver: "unknown",
-			Schema: "ocm_recommendations",
+			Schema: "ocp_recommendations",
 		},
 	}
 	err := main.CheckConfiguration(&config1)
@@ -227,7 +227,7 @@ func TestCheckConfigurationNegativeTestCases(t *testing.T) {
 	config3 := main.ConfigStruct{
 		Storage: main.StorageConfiguration{
 			Driver: "",
-			Schema: "ocm_recommendations",
+			Schema: "ocp_recommendations",
 		},
 	}
 	err = main.CheckConfiguration(&config3)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,51 @@
+version: "3.9"
+services:
+  database:
+    ports:
+      - 5432:5432
+    image: postgres:13.9
+    environment:
+      - POSTGRES_USER=postgres
+      - PGUSER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=aggregator
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 2s
+      timeout: 2s
+      retries: 4
+      start_period: 2s
+  db-writer-ocp:
+    image: quay.io/cloudservices/insights-results-aggregator:latest
+    environment:
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__TYPE=sql
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__DB_DRIVER=postgres
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__PG_PARAMS=sslmode=disable
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__PG_USERNAME=postgres
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__PG_PASSWORD=postgres
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__PG_HOST=database
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__PG_PORT=5432
+      - INSIGHTS_RESULTS_AGGREGATOR__OCP_RECOMMENDATIONS_STORAGE__PG_DB_NAME=aggregator
+      - INSIGHTS_RESULTS_AGGREGATOR__LOGGING__LOG_LEVEL=debug
+      - INSIGHTS_RESULTS_AGGREGATOR__LOGGING__DEBUG=true
+      - INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE=ocp_recommendations
+    command: bash -c "/insights-results-aggregator migration latest"
+    depends_on:
+      - db
+  db-writer-dvo:
+    image: quay.io/cloudservices/insights-results-aggregator:latest
+    environment:
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__TYPE=sql
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__DB_DRIVER=postgres
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__PG_PARAMS=sslmode=disable
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__PG_USERNAME=postgres
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__PG_PASSWORD=postgres
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__PG_HOST=database
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__PG_PORT=5432
+      - INSIGHTS_RESULTS_AGGREGATOR__DVO_RECOMMENDATIONS_STORAGE__PG_DB_NAME=aggregator
+      - INSIGHTS_RESULTS_AGGREGATOR__LOGGING__LOG_LEVEL=debug
+      - INSIGHTS_RESULTS_AGGREGATOR__LOGGING__DEBUG=true
+      - INSIGHTS_RESULTS_AGGREGATOR__STORAGE_BACKEND__USE=dvo_recommendations
+    command: bash -c "/insights-results-aggregator migration latest"
+    depends_on:
+      - db

--- a/export_test.go
+++ b/export_test.go
@@ -43,6 +43,7 @@ var (
 	PerformListOfOldConsumerErrors    = performListOfOldConsumerErrors
 	DeleteRecordFromTable             = deleteRecordFromTable
 	PerformCleanupInDB                = performCleanupInDB
+	PerformCleanupAllInDB             = performCleanupAllInDB
 	PerformVacuumDB                   = performVacuumDB
 	FillInDatabaseByTestData          = fillInDatabaseByTestData
 	InitDatabaseConnection            = initDatabaseConnection
@@ -57,7 +58,13 @@ var (
 	ReadClusterListFromCLIArgument = readClusterListFromCLIArgument
 	VacuumDB                       = vacuumDB
 	Cleanup                        = cleanup
+	CleanupAll                     = cleanupAll
 	FillInDatabase                 = fillInDatabase
 	DisplayOldRecords              = displayOldRecords
 	DetectMultipleRuleDisable      = detectMultipleRuleDisable
+
+	// constants
+	MaxAgeMissing     = maxAgeMissing
+	TablesToDeleteOCP = tablesToDeleteOCP
+	TablesToDeleteDVO = tablesToDeleteDVO
 )

--- a/storage.go
+++ b/storage.go
@@ -106,7 +106,13 @@ const (
 		DELETE FROM consumer_error
 		 WHERE consumed_at < NOW() - $1::INTERVAL`
 
-	deleteOldOCPRuleHits       = `` // TODO: How to filter? This table has no date column
+	deleteOldOCPRuleHits = `
+		DELETE FROM rule_hit
+		 WHERE (cluster_id, org_id) IN (
+			SELECT cluster, org_id
+			FROM report
+			WHERE reported_at < NOW() - $1::INTERVAL)`
+
 	deleteOldOCPRecommendation = `
 		DELETE FROM recommendation
 		 WHERE created_at < NOW() - $1::INTERVAL`

--- a/storage.go
+++ b/storage.go
@@ -58,6 +58,8 @@ const (
 	ageMsg                            = "age"
 	reportsCountMsg                   = "reports count"
 	maxAgeMissing                     = "max-age parameter is missing"
+	invalidSchemaMsg                  = "Invalid DB schema to be cleaned up: '%s'"
+	affectedMsg                       = "Affected"
 )
 
 // Other messages
@@ -785,7 +787,7 @@ func performCleanupInDB(connection *sql.DB,
 	case DBSchemaDVORecommendations:
 		tablesAndKeys = tablesAndKeysInDVODatabase
 	default:
-		return deletionsForTable, fmt.Errorf("Invalid DB schema to be cleaned up: '%s'", schema)
+		return deletionsForTable, fmt.Errorf(invalidSchemaMsg, schema)
 	}
 
 	// initialize counters
@@ -809,7 +811,7 @@ func performCleanupInDB(connection *sql.DB,
 					Msg("Unable to delete record")
 			} else {
 				log.Info().
-					Int("Affected", affected).
+					Int(affectedMsg, affected).
 					Str(tableName, tableAndKey.TableName).
 					Str(clusterNameMsg, string(clusterName)).
 					Msg("Delete record")
@@ -842,11 +844,11 @@ func performCleanupAllInDB(connection *sql.DB, schema, maxAge string) (
 	case DBSchemaDVORecommendations:
 		tablesAndDeleteStatements = tablesToDeleteDVO
 	default:
-		return deletionsForTable, fmt.Errorf("Invalid DB schema to be cleaned up: '%s'", schema)
+		return deletionsForTable, fmt.Errorf(invalidSchemaMsg, schema)
 	}
 
 	// perform cleanup for selected cluster names
-	log.Info().Msg("Cleanup started")
+	log.Info().Msg("Cleanup-all started")
 	for _, tableAndDeleteStatement := range tablesAndDeleteStatements {
 		// try to delete record from selected table
 		affected, err := deleteOldRecordsFromTable(connection,
@@ -856,16 +858,16 @@ func performCleanupAllInDB(connection *sql.DB, schema, maxAge string) (
 			log.Error().
 				Err(err).
 				Str(tableName, tableAndDeleteStatement.TableName).
-				Msg("Unable to delete record")
+				Msg("Unable to delete records")
 		} else {
 			log.Info().
-				Int("Affected", affected).
+				Int(affectedMsg, affected).
 				Str(tableName, tableAndDeleteStatement.TableName).
-				Msg("Delete record")
+				Msg("Delete records")
 			deletionsForTable[tableAndDeleteStatement.TableName] = affected
 		}
 	}
-	log.Info().Msg("Cleanup finished")
+	log.Info().Msg("Cleanup-all finished")
 	return deletionsForTable, nil
 }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,7 @@ const (
 	cluster2ID   = "567e4567-4321-12d3-a456-426614173777"
 	rule1ID      = "rule.test|KEY"
 	defaultOrgID = 42
+	maxAge       = "3 days"
 )
 
 // checkConnectionClose function performs mocked DB closing operation and checks
@@ -2044,4 +2046,135 @@ func TestDisplayAllOldDVORecordsFileOutput(t *testing.T) {
 	// delete test file from filesystem
 	err = os.Remove(outFile)
 	assert.NoError(t, err)
+}
+
+// TestPerformCleanupAllInDBForOCPDatabase checks the basic behaviour of
+// performCleanupAllInDB
+func TestPerformCleanupAllInDB(t *testing.T) {
+	for _, schema := range []string{cleaner.DBSchemaOCPRecommendations, cleaner.DBSchemaDVORecommendations} {
+		expectedResult := make(map[string]int)
+
+		t.Run(schema, func(t *testing.T) {
+			// prepare new mocked connection to database
+			connection, mock, err := sqlmock.New()
+			assert.NoError(t, err, "error creating SQL mock")
+
+			var tables []cleaner.TableAndDeleteStatement
+			switch schema {
+			case cleaner.DBSchemaOCPRecommendations:
+				tables = cleaner.TablesToDeleteOCP
+			case cleaner.DBSchemaDVORecommendations:
+				tables = cleaner.TablesToDeleteDVO
+			}
+
+			for _, tableAndDeleteStatement := range tables {
+				stmt := regexp.QuoteMeta(tableAndDeleteStatement.DeleteStatement)
+				mock.ExpectExec(stmt).WithArgs(maxAge).WillReturnResult(sqlmock.NewResult(1, 2))
+				// two deleted rows for each table
+				expectedResult[tableAndDeleteStatement.TableName] = 2
+			}
+
+			mock.ExpectClose()
+
+			deletedRows, err := cleaner.PerformCleanupAllInDB(connection, schema, maxAge)
+			assert.NoError(t, err, "error not expected while calling tested function")
+
+			// check tables have correct number of deleted rows for each table
+			for tableName, deletedRowCount := range deletedRows {
+				assert.Equal(t, expectedResult[tableName], deletedRowCount)
+			}
+
+			// check if DB can be closed successfully
+			checkConnectionClose(t, connection)
+
+			// check all DB expectactions happened correctly
+			checkAllExpectations(t, mock)
+		})
+	}
+}
+
+// TestPerformCleanupAllInDBNullSchema checks the basic behaviour of
+// performCleanupAllInDB function when the schema is null.
+func TestPerformCleanupAllInDBNullSchema(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
+
+	_, err = cleaner.PerformCleanupAllInDB(connection, "", maxAge)
+	assert.Error(t, err, "error is expected while calling tested function")
+
+	// check all DB expectactions happened correctly
+	checkAllExpectations(t, mock)
+}
+
+// TestPerformCleanupAllInDBWrongSchema checks the basic behaviour of
+// performCleanupAllInDB function with a wrong schema.
+func TestPerformCleanupAllInDBWrongSchema(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
+
+	_, err = cleaner.PerformCleanupAllInDB(connection, "wrong schema", maxAge)
+	assert.Error(t, err, "error is expected while calling tested function")
+
+	// check all DB expectactions happened correctly
+	checkAllExpectations(t, mock)
+}
+
+// TestPerformCleanupAllInDBOnDeleteError checks the basic behaviour of
+// performCleanupAllInDB function when error in called DeleteRecordFromTable.
+// is thrown
+func TestPerformCleanupAllInDBOnDeleteError(t *testing.T) {
+	mockedError := errors.New("delete from table")
+	for _, schema := range []string{cleaner.DBSchemaOCPRecommendations, cleaner.DBSchemaDVORecommendations} {
+		expectedResult := make(map[string]int)
+
+		t.Run(schema, func(t *testing.T) {
+			// prepare new mocked connection to database
+			connection, mock, err := sqlmock.New()
+			assert.NoError(t, err, "error creating SQL mock")
+
+			var tables []cleaner.TableAndDeleteStatement
+			switch schema {
+			case cleaner.DBSchemaOCPRecommendations:
+				tables = cleaner.TablesToDeleteOCP
+			case cleaner.DBSchemaDVORecommendations:
+				tables = cleaner.TablesToDeleteDVO
+			}
+
+			for _, tableAndDeleteStatement := range tables {
+				stmt := regexp.QuoteMeta(tableAndDeleteStatement.DeleteStatement)
+				mock.ExpectExec(stmt).WithArgs(maxAge).WillReturnError(mockedError)
+				expectedResult[tableAndDeleteStatement.TableName] = 0
+			}
+
+			mock.ExpectClose()
+
+			deletedRows, err := cleaner.PerformCleanupAllInDB(connection, schema, maxAge)
+			assert.NoError(t, err, "error not expected while calling tested function")
+			// There is no error because the cleaner just does log.Error, not exit
+
+			// check tables have correct number of deleted rows for each table
+			for tableName, deletedRowCount := range deletedRows {
+				assert.Equal(t, expectedResult[tableName], deletedRowCount)
+			}
+
+			// check if DB can be closed successfully
+			checkConnectionClose(t, connection)
+
+			// check all DB expectactions happened correctly
+			checkAllExpectations(t, mock)
+		})
+	}
+}
+
+// TestPerformCleanupAllInDBNoConnection checks the basic behaviour of
+// performCleanupAllInDB function when connection is not established.
+func TestPerformCleanupAllInDBNoConnection(t *testing.T) {
+	// connection that is not constructed correctly
+	var connection *sql.DB
+
+	_, err := cleaner.PerformCleanupAllInDB(connection, cleaner.DBSchemaOCPRecommendations, maxAge)
+
+	assert.Error(t, err, "error is expected while calling tested function")
 }

--- a/types.go
+++ b/types.go
@@ -61,6 +61,7 @@ type CliFlags struct {
 	Output                    string
 	PerformCleanup            bool
 	PerformCleanupAll         bool
+	DryRun                    bool
 	DetectMultipleRuleDisable bool
 	FillInDatabase            bool
 	VacuumDatabase            bool

--- a/types.go
+++ b/types.go
@@ -36,6 +36,9 @@ type TableAndKey struct {
 	KeyName   string
 }
 
+// TableAndDeleteStatement represents a delete statement for the given table.
+// The idea is to pass a parameter to filter by, for example a maximum age for
+// a reported_at column
 type TableAndDeleteStatement struct {
 	TableName       string
 	DeleteStatement string

--- a/types.go
+++ b/types.go
@@ -36,6 +36,11 @@ type TableAndKey struct {
 	KeyName   string
 }
 
+type TableAndDeleteStatement struct {
+	TableName       string
+	DeleteStatement string
+}
+
 // Summary represents summary info to be displayed in a table after cleanup
 // part
 type Summary struct {
@@ -52,6 +57,7 @@ type CliFlags struct {
 	PrintSummaryTable         bool
 	Output                    string
 	PerformCleanup            bool
+	PerformCleanupAll         bool
 	DetectMultipleRuleDisable bool
 	FillInDatabase            bool
 	VacuumDatabase            bool


### PR DESCRIPTION
# Description

Add target to clean up all the old records, no matter the cluster ID
## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Locally with a postgres DB.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
