### PR TITLE
[CCXDEV-12954] Rename dvo_report into dvo.dvo_report

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
       - [Table `recommendation`](#table-recommendation)
       - [Database tables affected by this service](#database-tables-affected-by-this-service)
     - [Database schema `dvo_recommendations`](#database-schema-dvo_recommendations)
-      - [Table `dvo_report`](#table-dvo_report)
+      - [Table `dvo.dvo_report`](#table-dvodvo_report)
   - [Documentation](#documentation-1)
     - [Documentation for source files from this repository](#documentation-for-source-files-from-this-repository)
     - [Documentation for unit tests from this repository](#documentation-for-unit-tests-from-this-repository)
@@ -449,7 +449,7 @@ Actually cleaning the data for given cluster:
 
 ### Database schema `dvo_recommendations`
 
-#### Table `dvo_report`
+#### Table `dvo.dvo_report`
 
 ```
     Column        |       Type                  | Modifiers

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Actually cleaning the data for given cluster:
  objects          | integer                     | not null
  reported_at      | timestamp without time zone |
  last_checked_at  | timestamp without time zone |
+ rule_hits_count  | jsonb                       |
 Indexes:
     "report_pkey" PRIMARY KEY, btree (org_id, cluster_id, namespace_id)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -308,7 +308,7 @@ Actually cleaning the data for given cluster:
 
 ### Database schema `dvo_recommendations`
 
-#### Table `dvo_report`
+#### Table `dvo.dvo_report`
 
 ```
     Column        |       Type                  | Modifiers

--- a/export_test.go
+++ b/export_test.go
@@ -67,5 +67,5 @@ var (
 	MaxAgeMissing     = maxAgeMissing
 	TablesToDeleteOCP = tablesToDeleteOCP
 	TablesToDeleteDVO = tablesToDeleteDVO
-	EmptyJSON         = emptyJson
+	emptyJSON         = emptyJSON
 )

--- a/export_test.go
+++ b/export_test.go
@@ -67,4 +67,5 @@ var (
 	MaxAgeMissing     = maxAgeMissing
 	TablesToDeleteOCP = tablesToDeleteOCP
 	TablesToDeleteDVO = tablesToDeleteDVO
+	EmptyJSON         = emptyJson
 )

--- a/export_test.go
+++ b/export_test.go
@@ -67,5 +67,5 @@ var (
 	MaxAgeMissing     = maxAgeMissing
 	TablesToDeleteOCP = tablesToDeleteOCP
 	TablesToDeleteDVO = tablesToDeleteDVO
-	emptyJSON         = emptyJSON
+	EmptyJSON         = emptyJSON
 )

--- a/storage.go
+++ b/storage.go
@@ -554,7 +554,7 @@ func performListOfOldDVOReports(connection *sql.DB, maxAge string, writer *bufio
 // advisor_ratings table
 func performListOfOldRatings(connection *sql.DB, maxAge string) error {
 	return listOldDatabaseRecords(connection, maxAge, nil, selectOldAdvisorRatings, "List of old Advisor ratings", "ratings count",
-		func(rows *sql.Rows, writer *bufio.Writer) (int, error) {
+		func(rows *sql.Rows, _ *bufio.Writer) (int, error) {
 			// used to compute a real record age
 			now := time.Now()
 
@@ -606,7 +606,7 @@ func performListOfOldRatings(connection *sql.DB, maxAge string) error {
 // consumer_errors table
 func performListOfOldConsumerErrors(connection *sql.DB, maxAge string) error {
 	return listOldDatabaseRecords(connection, maxAge, nil, selectOldConsumerErrors, "List of old consumer errors", "errors count",
-		func(rows *sql.Rows, writer *bufio.Writer) (int, error) {
+		func(rows *sql.Rows, _ *bufio.Writer) (int, error) {
 			// used to compute a real record age
 			now := time.Now()
 

--- a/storage.go
+++ b/storage.go
@@ -130,7 +130,7 @@ const (
 	DBSchemaDVORecommendations = "dvo_recommendations"
 )
 
-var emptyJson = json.RawMessage(`{}`)
+var emptyJSON = json.RawMessage(`{}`)
 
 // initDatabaseConnection initializes driver, checks if it's supported and
 // initializes connection to the storage.
@@ -995,7 +995,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         6,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   emptyJson,
+			RuleHitsCount:   emptyJSON,
 		},
 		{
 			OrgID:           1,
@@ -1007,7 +1007,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         5,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   emptyJson,
+			RuleHitsCount:   emptyJSON,
 		},
 		{
 			OrgID:           2,
@@ -1019,7 +1019,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         4,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   emptyJson,
+			RuleHitsCount:   emptyJSON,
 		},
 		{
 			OrgID:           3,
@@ -1031,7 +1031,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         3,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   emptyJson,
+			RuleHitsCount:   emptyJSON,
 		},
 		{
 			OrgID:           3,
@@ -1043,7 +1043,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         2,
 			ReportedAt:      "2022-01-01",
 			LastCheckedAt:   "2022-01-01",
-			RuleHitsCount:   emptyJson,
+			RuleHitsCount:   emptyJSON,
 		},
 		{
 			OrgID:           3,
@@ -1055,7 +1055,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         1,
 			ReportedAt:      "2023-01-01",
 			LastCheckedAt:   "2023-01-01",
-			RuleHitsCount:   emptyJson,
+			RuleHitsCount:   emptyJSON,
 		},
 	}
 

--- a/storage.go
+++ b/storage.go
@@ -130,6 +130,8 @@ const (
 	DBSchemaDVORecommendations = "dvo_recommendations"
 )
 
+var emptyJson = json.RawMessage(`{}`)
+
 // initDatabaseConnection initializes driver, checks if it's supported and
 // initializes connection to the storage.
 func initDatabaseConnection(configuration *StorageConfiguration) (*sql.DB, error) {
@@ -993,7 +995,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         6,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   json.RawMessage(`{}`),
+			RuleHitsCount:   emptyJson,
 		},
 		{
 			OrgID:           1,
@@ -1005,7 +1007,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         5,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   json.RawMessage(`{}`),
+			RuleHitsCount:   emptyJson,
 		},
 		{
 			OrgID:           2,
@@ -1017,7 +1019,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         4,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   json.RawMessage(`{}`),
+			RuleHitsCount:   emptyJson,
 		},
 		{
 			OrgID:           3,
@@ -1029,7 +1031,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         3,
 			ReportedAt:      "2021-01-01",
 			LastCheckedAt:   "2021-01-01",
-			RuleHitsCount:   json.RawMessage(`{}`),
+			RuleHitsCount:   emptyJson,
 		},
 		{
 			OrgID:           3,
@@ -1041,7 +1043,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         2,
 			ReportedAt:      "2022-01-01",
 			LastCheckedAt:   "2022-01-01",
-			RuleHitsCount:   json.RawMessage(`{}`),
+			RuleHitsCount:   emptyJson,
 		},
 		{
 			OrgID:           3,
@@ -1053,7 +1055,7 @@ func fillInDVODatabaseByTestData(connection *sql.DB) error {
 			Objects:         1,
 			ReportedAt:      "2023-01-01",
 			LastCheckedAt:   "2023-01-01",
-			RuleHitsCount:   json.RawMessage(`{}`),
+			RuleHitsCount:   emptyJson,
 		},
 	}
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1484,15 +1484,14 @@ func TestFillInDVODatabaseByTestData(t *testing.T) {
 	connection, mock, err := sqlmock.New()
 	assert.NoError(t, err, "error creating SQL mock")
 
-	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
+	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure pod does not accept unsafe traffic by isolating it with a NetworkPolicy.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2022-01-01", "2022-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2023-01-01", "2023-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectClose()
 
 	err = cleaner.FillInDatabaseByTestData(connection, cleaner.DBSchemaDVORecommendations)
@@ -1516,14 +1515,14 @@ func TestFillInDVODatabaseByTestDataOnError1(t *testing.T) {
 	connection, mock, err := sqlmock.New()
 	assert.NoError(t, err, "error creating SQL mock")
 
-	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
+	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure pod does not accept unsafe traffic by isolating it with a NetworkPolicy.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2022-01-01", "2022-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2023-01-01", "2023-01-01").WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.EmptyJSON).WillReturnError(mockedError)
 
 	mock.ExpectClose()
 
@@ -1550,14 +1549,14 @@ func TestFillInDVODatabaseByTestDataOnError2(t *testing.T) {
 	connection, mock, err := sqlmock.New()
 	assert.NoError(t, err, "error creating SQL mock")
 
-	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
+	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnError(mockedError)
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure pod does not accept unsafe traffic by isolating it with a NetworkPolicy.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2022-01-01", "2022-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Set memory requests and limits for your container based on its requirements.", "", "2023-01-01", "2023-01-01").WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", &cleaner.EmptyJSON).WillReturnError(mockedError)
 
 	mock.ExpectClose()
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1486,12 +1486,12 @@ func TestFillInDVODatabaseByTestData(t *testing.T) {
 
 	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectClose()
 
 	err = cleaner.FillInDatabaseByTestData(connection, cleaner.DBSchemaDVORecommendations)
@@ -1517,12 +1517,12 @@ func TestFillInDVODatabaseByTestDataOnError1(t *testing.T) {
 
 	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.EmptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.emptyJSON).WillReturnError(mockedError)
 
 	mock.ExpectClose()
 
@@ -1551,12 +1551,12 @@ func TestFillInDVODatabaseByTestDataOnError2(t *testing.T) {
 
 	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnError(mockedError)
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", &cleaner.EmptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", &cleaner.emptyJSON).WillReturnError(mockedError)
 
 	mock.ExpectClose()
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1484,7 +1484,7 @@ func TestFillInDVODatabaseByTestData(t *testing.T) {
 	connection, mock, err := sqlmock.New()
 	assert.NoError(t, err, "error creating SQL mock")
 
-	const insert = "INSERT INTO dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
+	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
 
 	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1516,7 +1516,7 @@ func TestFillInDVODatabaseByTestDataOnError1(t *testing.T) {
 	connection, mock, err := sqlmock.New()
 	assert.NoError(t, err, "error creating SQL mock")
 
-	const insert = "INSERT INTO dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
+	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
 
 	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1550,7 +1550,7 @@ func TestFillInDVODatabaseByTestDataOnError2(t *testing.T) {
 	connection, mock, err := sqlmock.New()
 	assert.NoError(t, err, "error creating SQL mock")
 
-	const insert = "INSERT INTO dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
+	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\);"
 
 	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnError(mockedError)
 	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", "Ensure the host's network namespace is not shared.", "", "2021-01-01", "2021-01-01").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1870,7 +1870,7 @@ func TestPerformListOfOldDVOReportsNoResults(t *testing.T) {
 	rows := sqlmock.NewRows([]string{})
 
 	// expected query performed by tested function
-	expectedQuery := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	expectedQuery := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo.dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
 	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
 	mock.ExpectClose()
 
@@ -1899,7 +1899,7 @@ func TestPerformListOfOldDVOReportsScanError(t *testing.T) {
 	rows.AddRow(42, nil, reportedAt, updatedAt)
 
 	// expected query performed by tested function
-	expectedQuery := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	expectedQuery := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo.dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
 	mock.ExpectQuery(expectedQuery).WillReturnRows(rows)
 	mock.ExpectClose()
 
@@ -1927,7 +1927,7 @@ func TestPerformListOfOldDVOReportsDBError(t *testing.T) {
 	assert.NoError(t, err, "error creating SQL mock")
 
 	// expected query performed by tested function
-	expectedQuery := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	expectedQuery := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo.dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
 	mock.ExpectQuery(expectedQuery).WillReturnError(mockedError)
 	mock.ExpectClose()
 
@@ -1960,7 +1960,7 @@ func TestDisplayAllOldDVORecordsNoOutput(t *testing.T) {
 	rows.AddRow(1, cluster1ID, reportedAt, updatedAt)
 
 	// expected queries performed by tested function
-	expectedQuery1 := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	expectedQuery1 := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo.dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
 	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
 
 	mock.ExpectClose()
@@ -1994,7 +1994,7 @@ func TestDisplayAllOldDVORecordsFileOutput(t *testing.T) {
 	rows.AddRow(orgID, cluster2ID, reportedAt, updatedAt)
 
 	// expected queries performed by tested function
-	expectedQuery1 := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
+	expectedQuery1 := "SELECT org_id, cluster_id, reported_at, last_checked_at FROM dvo.dvo_report WHERE reported_at < NOW\\(\\) - \\$1::INTERVAL ORDER BY reported_at"
 	mock.ExpectQuery(expectedQuery1).WillReturnRows(rows)
 
 	mock.ExpectClose()

--- a/storage_test.go
+++ b/storage_test.go
@@ -1486,12 +1486,12 @@ func TestFillInDVODatabaseByTestData(t *testing.T) {
 
 	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectClose()
 
 	err = cleaner.FillInDatabaseByTestData(connection, cleaner.DBSchemaDVORecommendations)
@@ -1517,12 +1517,12 @@ func TestFillInDVODatabaseByTestDataOnError1(t *testing.T) {
 
 	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.emptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", cleaner.EmptyJSON).WillReturnError(mockedError)
 
 	mock.ExpectClose()
 
@@ -1551,12 +1551,12 @@ func TestFillInDVODatabaseByTestDataOnError2(t *testing.T) {
 
 	const insert = "INSERT INTO dvo.dvo_report \\(org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count\\) values \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\);"
 
-	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnError(mockedError)
-	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", &cleaner.emptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", &cleaner.emptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000001-0001-0001-0001-000000000001", "fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f", "not set", "", 1, 6, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnError(mockedError)
+	mock.ExpectExec(insert).WithArgs(1, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 2, 5, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(2, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 3, 4, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000001-0001-0001-0001-000000000001", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 4, 3, "2021-01-01", "2021-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000002-0002-0002-0002-000000000002", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 5, 2, "2022-01-01", "2022-01-01", &cleaner.EmptyJSON).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insert).WithArgs(3, "00000003-0003-0003-0003-000000000003", "e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c", "not set", "", 6, 1, "2023-01-01", "2023-01-01", &cleaner.EmptyJSON).WillReturnError(mockedError)
 
 	mock.ExpectClose()
 


### PR DESCRIPTION
# Description

Rename `dvo_report` into `dvo.dvo_report`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Locally:

1. Run `podman-compose up -d`
2. Check the dvo-writer created the table:
```
aggregator=# SELECT * FROM dvo.dvo_report;
 org_id | cluster_id | namespace_id | namespace_name | report | recommendations | objects | reported_at | last_checked_at | rule_hits_count 
--------+------------+--------------+----------------+--------+-----------------+---------+-------------+-----------------+-----------------
(0 rows)
```
3. Fill the DB with some mock data:
```
❯ ./insights-results-aggregator-cleaner -fill-in-db
{"level":"info","filename":"config","time":"2024-06-26T09:29:54+02:00","message":"parsing configuration file"}
Clowder is disabled
9:29AM DBG Started
9:29AM INF DB connection configuration driverName=postgres
9:29AM INF Fill-in database started
9:29AM INF inserting into DVO database Insert statement="\n\t    INSERT INTO dvo.dvo_report\n\t           (org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count)\n\t\t   values\n\t\t   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);"
9:29AM INF inserting into DVO database Insert statement="\n\t    INSERT INTO dvo.dvo_report\n\t           (org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count)\n\t\t   values\n\t\t   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);"
9:29AM INF inserting into DVO database Insert statement="\n\t    INSERT INTO dvo.dvo_report\n\t           (org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count)\n\t\t   values\n\t\t   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);"
9:29AM INF inserting into DVO database Insert statement="\n\t    INSERT INTO dvo.dvo_report\n\t           (org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count)\n\t\t   values\n\t\t   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);"
9:29AM INF inserting into DVO database Insert statement="\n\t    INSERT INTO dvo.dvo_report\n\t           (org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count)\n\t\t   values\n\t\t   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);"
9:29AM INF inserting into DVO database Insert statement="\n\t    INSERT INTO dvo.dvo_report\n\t           (org_id, cluster_id, namespace_id, namespace_name, report, recommendations, objects, reported_at, last_checked_at, rule_hits_count)\n\t\t   values\n\t\t   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);"
9:29AM INF Fill-in DVO database finished
9:29AM DBG Finished
```
4. Check with a dry-run:
```
❯ ./insights-results-aggregator-cleaner -cleanup-all -dry-run
{"level":"info","filename":"config","time":"2024-06-26T09:30:01+02:00","message":"parsing configuration file"}
Clowder is disabled
9:30AM DBG Started
9:30AM INF DB connection configuration driverName=postgres
9:30AM DBG Cleaning all old records from DB Max age="90 days"
9:30AM INF Cleanup-all started
9:30AM INF Delete records Affected=6 Dry run=true table=dvo.dvo_report
9:30AM INF Cleanup-all finished
9:30AM DBG Finished
```
5. Check in psql
```
aggregator=# SELECT * FROM dvo.dvo_report;
 org_id |              cluster_id              |             namespace_id             | namespace_name | report | recommendations | objects |     reported_at     |   last_checked_at   | rule_hits_count 
--------+--------------------------------------+--------------------------------------+----------------+--------+-----------------+---------+---------------------+---------------------+-----------------
      1 | 00000001-0001-0001-0001-000000000001 | fbcbe2d3-e398-4b40-9d5e-4eb46fe8286f | not set        |        |               1 |       6 | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | {}
      1 | 00000002-0002-0002-0002-000000000002 | e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c | not set        |        |               2 |       5 | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | {}
      2 | 00000003-0003-0003-0003-000000000003 | e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c | not set        |        |               3 |       4 | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | {}
      3 | 00000001-0001-0001-0001-000000000001 | e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c | not set        |        |               4 |       3 | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | {}
      3 | 00000002-0002-0002-0002-000000000002 | e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c | not set        |        |               5 |       2 | 2022-01-01 00:00:00 | 2022-01-01 00:00:00 | {}
      3 | 00000003-0003-0003-0003-000000000003 | e6ed9bb3-efc3-46a6-b3ae-3f1a6e59546c | not set        |        |               6 |       1 | 2023-01-01 00:00:00 | 2023-01-01 00:00:00 | {}
(6 rows)
```

6. Clean up
```
❯ ./insights-results-aggregator-cleaner -cleanup-all -dry-run=false
{"level":"info","filename":"config","time":"2024-06-26T09:30:09+02:00","message":"parsing configuration file"}
Clowder is disabled
9:30AM DBG Started
9:30AM INF DB connection configuration driverName=postgres
9:30AM DBG Cleaning all old records from DB Max age="90 days"
9:30AM INF Cleanup-all started
9:30AM INF Delete records Affected=6 Dry run=false table=dvo.dvo_report
9:30AM INF Cleanup-all finished
9:30AM DBG Finished
```

7. Check in psql
```
aggregator=# SELECT * FROM dvo.dvo_report;
 org_id | cluster_id | namespace_id | namespace_name | report | recommendations | objects | reported_at | last_checked_at | rule_hits_count 
--------+------------+--------------+----------------+--------+-----------------+---------+-------------+-----------------+-----------------
(0 rows)
```

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
