### PR TITLE
Allow to specify the max age of records by parameter

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -42,7 +42,7 @@ objects:
             - name: INSIGHTS_RESULTS_CLEANER__LOGGING__LOG_DEVEL
               value: "${LOG_LEVEL}"
             - name: INSIGHTS_RESULTS_CLEANER__CLEANER__MAX_AGE
-              value: "90 days"
+              value: "${MAX_AGE}"
           resources:
             limits:
               cpu: ${CPU_LIMIT}
@@ -98,3 +98,6 @@ parameters:
   value: "600"
 - name: PG_PARAMS
   value: sslmode=require
+- name: MAX_AGE
+  description: Maximum age allowed to be kept in the database
+  value: "90 days"


### PR DESCRIPTION
# Description

Add a new parameter into ClowdApp to allow the definition of the maximum age of the records to be kept in the database. Records older than this age will be removed (if a real run is performed)

## Type of change

- Configuration update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
