### PR TITLE
Ignore the schema when running -cleanup-all

### DIFF
--- a/cleaner.go
+++ b/cleaner.go
@@ -302,8 +302,8 @@ func cleanup(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags,
 }
 
 // cleanup function starts the cleanup-all operation
-func cleanupAll(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags, schema string) (int, error) {
-	deletionsForTable, err := performCleanupAllInDB(connection, schema, configuration.Cleaner.MaxAge, cliFlags.DryRun)
+func cleanupAll(configuration *ConfigStruct, connection *sql.DB, cliFlags CliFlags) (int, error) {
+	deletionsForTable, err := performCleanupAllInDB(connection, configuration.Cleaner.MaxAge, cliFlags.DryRun)
 	if err != nil {
 		log.Err(err).Msg("Performing cleanup-all")
 		return ExitStatusPerformCleanupError, err
@@ -379,7 +379,7 @@ func doSelectedOperation(configuration *ConfigStruct, connection *sql.DB, cliFla
 	case cliFlags.VacuumDatabase:
 		return vacuumDB(connection)
 	case cliFlags.PerformCleanupAll:
-		return cleanupAll(configuration, connection, cliFlags, configuration.Storage.Schema)
+		return cleanupAll(configuration, connection, cliFlags)
 	case cliFlags.PerformCleanup:
 		return cleanup(configuration, connection, cliFlags, configuration.Storage.Schema)
 	case cliFlags.DetectMultipleRuleDisable:

--- a/cleaner_test.go
+++ b/cleaner_test.go
@@ -21,7 +21,6 @@ package main_test
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -32,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tisnik/go-capture"
 
+	cleaner "github.com/RedHatInsights/insights-results-aggregator-cleaner"
 	main "github.com/RedHatInsights/insights-results-aggregator-cleaner"
 )
 
@@ -1040,51 +1040,38 @@ func TestCleanupCheckSummaryTableContent(t *testing.T) {
 // TestCleanupAll check the function cleanupAll when
 // summary table should not be printed
 func TestCleanupAll(t *testing.T) {
-	for _, schema := range []string{main.DBSchemaOCPRecommendations, main.DBSchemaDVORecommendations} {
-		t.Run(fmt.Sprintf("Schema: %s", schema), func(t *testing.T) {
-			// prepare new mocked connection to database
-			connection, mock, err := sqlmock.New()
-			assert.NoError(t, err, "error creating SQL mock")
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
 
-			// stub for structures needed to call the tested function
-			configuration := main.ConfigStruct{}
+	// stub for structures needed to call the tested function
+	configuration := main.ConfigStruct{}
 
-			configuration.Cleaner = main.CleanerConfiguration{
-				MaxAge: "3 days",
-			}
-			configuration.Storage.Schema = schema
-
-			cliFlags := main.CliFlags{
-				ShowVersion:       false,
-				ShowAuthors:       false,
-				ShowConfiguration: false,
-				PrintSummaryTable: false,
-			}
-
-			var tables []main.TableAndDeleteStatement
-			switch configuration.Storage.Schema {
-			case main.DBSchemaOCPRecommendations:
-				tables = main.TablesToDeleteOCP
-			case main.DBSchemaDVORecommendations:
-				tables = main.TablesToDeleteDVO
-			}
-
-			for range tables {
-				mock.ExpectExec("DELETE*").WithArgs(configuration.Cleaner.MaxAge).
-					WillReturnResult(sqlmock.NewResult(1, 2))
-			}
-			mock.ExpectClose()
-
-			// call the tested function
-			status, err := main.CleanupAll(&configuration, connection, cliFlags, schema)
-
-			// error is not expected
-			assert.NoError(t, err, "error is not expected while calling main.cleanupAll")
-
-			// check the status
-			assert.Equal(t, status, main.ExitStatusOK)
-		})
+	configuration.Cleaner = main.CleanerConfiguration{
+		MaxAge: "3 days",
 	}
+
+	cliFlags := main.CliFlags{
+		ShowVersion:       false,
+		ShowAuthors:       false,
+		ShowConfiguration: false,
+		PrintSummaryTable: false,
+	}
+
+	for range cleaner.AllTablesToDelete {
+		mock.ExpectExec("DELETE*").WithArgs(configuration.Cleaner.MaxAge).
+			WillReturnResult(sqlmock.NewResult(1, 2))
+	}
+	mock.ExpectClose()
+
+	// call the tested function
+	status, err := main.CleanupAll(&configuration, connection, cliFlags)
+
+	// error is not expected
+	assert.NoError(t, err, "error is not expected while calling main.cleanupAll")
+
+	// check the status
+	assert.Equal(t, status, main.ExitStatusOK)
 }
 
 // TestCleanupAllMissingMaxAge check the function cleanup fails if no MaxAge
@@ -1109,7 +1096,7 @@ func TestCleanupAllMissingMaxAge(t *testing.T) {
 	}
 
 	// call the tested function
-	status, err := main.CleanupAll(&configuration, connection, cliFlags, main.DBSchemaOCPRecommendations)
+	status, err := main.CleanupAll(&configuration, connection, cliFlags)
 
 	// error is not expected
 	assert.EqualError(t, err, main.MaxAgeMissing)

--- a/export_test.go
+++ b/export_test.go
@@ -67,5 +67,6 @@ var (
 	MaxAgeMissing     = maxAgeMissing
 	TablesToDeleteOCP = tablesToDeleteOCP
 	TablesToDeleteDVO = tablesToDeleteDVO
+	AllTablesToDelete = allTablesToDelete
 	EmptyJSON         = emptyJSON
 )

--- a/storage.go
+++ b/storage.go
@@ -679,24 +679,24 @@ func deleteRecordFromTable(connection *sql.DB, table, key string, clusterName Cl
 }
 
 var (
-  tablesToDeleteOCP = []TableAndDeleteStatement{
-	{
-		TableName:       "rule_hit",
-		DeleteStatement: deleteOldOCPRuleHits,
-	},
-	{
-		TableName:       "report",
-		DeleteStatement: deleteOldOCPReports,
-	},
-	{
-		TableName:       "consumer_error",
-		DeleteStatement: deleteOldConsumerErrors,
-	},
-	{
-		TableName:       "recommendation",
-		DeleteStatement: deleteOldOCPRecommendation,
-	},
-}
+	tablesToDeleteOCP = []TableAndDeleteStatement{
+		{
+			TableName:       "rule_hit",
+			DeleteStatement: deleteOldOCPRuleHits,
+		},
+		{
+			TableName:       "report",
+			DeleteStatement: deleteOldOCPReports,
+		},
+		{
+			TableName:       "consumer_error",
+			DeleteStatement: deleteOldConsumerErrors,
+		},
+		{
+			TableName:       "recommendation",
+			DeleteStatement: deleteOldOCPRecommendation,
+		},
+	}
 
 	tablesToDeleteDVO = []TableAndDeleteStatement{
 		{

--- a/storage.go
+++ b/storage.go
@@ -678,31 +678,34 @@ func deleteRecordFromTable(connection *sql.DB, table, key string, clusterName Cl
 	return int(affected), nil
 }
 
-var tablesToDeleteOCP = []TableAndDeleteStatement{
-	{
-		TableName:       "report",
-		DeleteStatement: deleteOldOCPReports,
-	},
-	{
-		TableName:       "consumer_error",
-		DeleteStatement: deleteOldConsumerErrors,
-	},
-	{
-		TableName:       "rule_hit",
-		DeleteStatement: deleteOldOCPRuleHits,
-	},
-	{
-		TableName:       "recommendation",
-		DeleteStatement: deleteOldOCPRecommendation,
-	},
-}
+var (
+	tablesToDeleteOCP = []TableAndDeleteStatement{
+		{
+			TableName:       "report",
+			DeleteStatement: deleteOldOCPReports,
+		},
+		{
+			TableName:       "consumer_error",
+			DeleteStatement: deleteOldConsumerErrors,
+		},
+		{
+			TableName:       "rule_hit",
+			DeleteStatement: deleteOldOCPRuleHits,
+		},
+		{
+			TableName:       "recommendation",
+			DeleteStatement: deleteOldOCPRecommendation,
+		},
+	}
 
-var tablesToDeleteDVO = []TableAndDeleteStatement{
-	{
-		TableName:       "dvo.dvo_report",
-		DeleteStatement: deleteOldDVOReports,
-	},
-}
+	tablesToDeleteDVO = []TableAndDeleteStatement{
+		{
+			TableName:       "dvo.dvo_report",
+			DeleteStatement: deleteOldDVOReports,
+		},
+	}
+	allTablesToDelete = append(tablesToDeleteOCP, tablesToDeleteDVO...)
+)
 
 // deleteOldRecordsFromTable function deletes old records from database
 // each delete query must have just one parameter that will be populated with
@@ -837,7 +840,7 @@ func performCleanupInDB(connection *sql.DB,
 }
 
 // performCleanupAllInDB function cleans up all data for all cluster names
-func performCleanupAllInDB(connection *sql.DB, schema, maxAge string, dryRun bool) (
+func performCleanupAllInDB(connection *sql.DB, maxAge string, dryRun bool) (
 	map[string]int, error) {
 	deletionsForTable := make(map[string]int)
 	if maxAge == "" {
@@ -850,19 +853,9 @@ func performCleanupAllInDB(connection *sql.DB, schema, maxAge string, dryRun boo
 		return deletionsForTable, errors.New(connectionNotEstablished)
 	}
 
-	var tablesAndDeleteStatements []TableAndDeleteStatement
-	switch schema {
-	case DBSchemaOCPRecommendations:
-		tablesAndDeleteStatements = tablesToDeleteOCP
-	case DBSchemaDVORecommendations:
-		tablesAndDeleteStatements = tablesToDeleteDVO
-	default:
-		return deletionsForTable, fmt.Errorf(invalidSchemaMsg, schema)
-	}
-
 	// perform cleanup for selected cluster names
 	log.Info().Msg("Cleanup-all started")
-	for _, tableAndDeleteStatement := range tablesAndDeleteStatements {
+	for _, tableAndDeleteStatement := range allTablesToDelete {
 		// try to delete record from selected table
 		affected, err := deleteOldRecordsFromTable(connection,
 			tableAndDeleteStatement.DeleteStatement,

--- a/storage_test.go
+++ b/storage_test.go
@@ -2050,112 +2050,28 @@ func TestDisplayAllOldDVORecordsFileOutput(t *testing.T) {
 // TestPerformCleanupAllInDBForOCPDatabase checks the basic behaviour of
 // performCleanupAllInDB
 func TestPerformCleanupAllInDB(t *testing.T) {
-	for _, schema := range []string{cleaner.DBSchemaOCPRecommendations, cleaner.DBSchemaDVORecommendations} {
-		for _, dryRun := range []bool{true, false} {
-			expectedResult := make(map[string]int)
-
-			t.Run(fmt.Sprintf("Schema: %s - Dry run: %t", schema, dryRun), func(t *testing.T) {
-				// prepare new mocked connection to database
-				connection, mock, err := sqlmock.New()
-				assert.NoError(t, err, "error creating SQL mock")
-
-				var tables []cleaner.TableAndDeleteStatement
-				switch schema {
-				case cleaner.DBSchemaOCPRecommendations:
-					tables = cleaner.TablesToDeleteOCP
-				case cleaner.DBSchemaDVORecommendations:
-					tables = cleaner.TablesToDeleteDVO
-				}
-
-				for _, tableAndDeleteStatement := range tables {
-					stmt := regexp.QuoteMeta(tableAndDeleteStatement.DeleteStatement)
-					if dryRun {
-						stmt = strings.Replace(stmt, "DELETE", "SELECT", -1)
-					}
-					mock.ExpectExec(stmt).WithArgs(maxAge).WillReturnResult(sqlmock.NewResult(1, 2))
-					// two deleted rows for each table
-					expectedResult[tableAndDeleteStatement.TableName] = 2
-				}
-
-				mock.ExpectClose()
-
-				deletedRows, err := cleaner.PerformCleanupAllInDB(connection, schema, maxAge, dryRun)
-				assert.NoError(t, err, "error not expected while calling tested function")
-
-				// check tables have correct number of deleted rows for each table
-				for tableName, deletedRowCount := range deletedRows {
-					assert.Equal(t, expectedResult[tableName], deletedRowCount)
-				}
-
-				// check if DB can be closed successfully
-				checkConnectionClose(t, connection)
-
-				// check all DB expectactions happened correctly
-				checkAllExpectations(t, mock)
-			})
-		}
-	}
-}
-
-// TestPerformCleanupAllInDBNullSchema checks the basic behaviour of
-// performCleanupAllInDB function when the schema is null.
-func TestPerformCleanupAllInDBNullSchema(t *testing.T) {
-	// prepare new mocked connection to database
-	connection, mock, err := sqlmock.New()
-	assert.NoError(t, err, "error creating SQL mock")
-
-	_, err = cleaner.PerformCleanupAllInDB(connection, "", maxAge, false)
-	assert.Error(t, err, "error is expected while calling tested function")
-
-	// check all DB expectactions happened correctly
-	checkAllExpectations(t, mock)
-}
-
-// TestPerformCleanupAllInDBWrongSchema checks the basic behaviour of
-// performCleanupAllInDB function with a wrong schema.
-func TestPerformCleanupAllInDBWrongSchema(t *testing.T) {
-	// prepare new mocked connection to database
-	connection, mock, err := sqlmock.New()
-	assert.NoError(t, err, "error creating SQL mock")
-
-	_, err = cleaner.PerformCleanupAllInDB(connection, "wrong schema", maxAge, false)
-	assert.Error(t, err, "error is expected while calling tested function")
-
-	// check all DB expectactions happened correctly
-	checkAllExpectations(t, mock)
-}
-
-// TestPerformCleanupAllInDBOnDeleteError checks the basic behaviour of
-// performCleanupAllInDB function when error in called DeleteRecordFromTable.
-// is thrown
-func TestPerformCleanupAllInDBOnDeleteError(t *testing.T) {
-	mockedError := errors.New("delete from table")
-	for _, schema := range []string{cleaner.DBSchemaOCPRecommendations, cleaner.DBSchemaDVORecommendations} {
+	for _, dryRun := range []bool{true, false} {
 		expectedResult := make(map[string]int)
 
-		t.Run(schema, func(t *testing.T) {
+		t.Run(fmt.Sprintf("Dry run: %t", dryRun), func(t *testing.T) {
 			// prepare new mocked connection to database
 			connection, mock, err := sqlmock.New()
 			assert.NoError(t, err, "error creating SQL mock")
 
-			var tables []cleaner.TableAndDeleteStatement
-			switch schema {
-			case cleaner.DBSchemaOCPRecommendations:
-				tables = cleaner.TablesToDeleteOCP
-			case cleaner.DBSchemaDVORecommendations:
-				tables = cleaner.TablesToDeleteDVO
+			for _, tableAndDeleteStatement := range cleaner.AllTablesToDelete {
+				stmt := regexp.QuoteMeta(tableAndDeleteStatement.DeleteStatement)
+				if dryRun {
+					stmt = strings.Replace(stmt, "DELETE", "SELECT", -1)
+				}
+				mock.ExpectExec(stmt).WithArgs(maxAge).WillReturnResult(sqlmock.NewResult(1, 2))
+				// two deleted rows for each table
+				expectedResult[tableAndDeleteStatement.TableName] = 2
 			}
-
-			// just the first table query is expected as it will return an error
-			tableAndDeleteStatement := tables[0]
-			stmt := regexp.QuoteMeta(tableAndDeleteStatement.DeleteStatement)
-			mock.ExpectExec(stmt).WithArgs(maxAge).WillReturnError(mockedError)
-			expectedResult[tableAndDeleteStatement.TableName] = 0
 
 			mock.ExpectClose()
 
-			deletedRows, err := cleaner.PerformCleanupAllInDB(connection, schema, maxAge, false)
-			assert.Error(t, err, "error expected while calling tested function")
+			deletedRows, err := cleaner.PerformCleanupAllInDB(connection, maxAge, dryRun)
+			assert.NoError(t, err, "error not expected while calling tested function")
 
 			// check tables have correct number of deleted rows for each table
 			for tableName, deletedRowCount := range deletedRows {
@@ -2171,13 +2087,61 @@ func TestPerformCleanupAllInDBOnDeleteError(t *testing.T) {
 	}
 }
 
+// TestPerformCleanupAllInDBNullSchema checks the basic behaviour of
+// performCleanupAllInDB function when the schema is null.
+func TestPerformCleanupAllInDBNullSchema(t *testing.T) {
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
+
+	_, err = cleaner.PerformCleanupAllInDB(connection, maxAge, false)
+	assert.Error(t, err, "error is expected while calling tested function")
+
+	// check all DB expectactions happened correctly
+	checkAllExpectations(t, mock)
+}
+
+// TestPerformCleanupAllInDBOnDeleteError checks the basic behaviour of
+// performCleanupAllInDB function when error in called DeleteRecordFromTable.
+// is thrown
+func TestPerformCleanupAllInDBOnDeleteError(t *testing.T) {
+	mockedError := errors.New("delete from table")
+	expectedResult := make(map[string]int)
+
+	// prepare new mocked connection to database
+	connection, mock, err := sqlmock.New()
+	assert.NoError(t, err, "error creating SQL mock")
+
+	// just the first table query is expected as it will return an error
+	tableAndDeleteStatement := cleaner.AllTablesToDelete[0]
+	stmt := regexp.QuoteMeta(tableAndDeleteStatement.DeleteStatement)
+	mock.ExpectExec(stmt).WithArgs(maxAge).WillReturnError(mockedError)
+	expectedResult[tableAndDeleteStatement.TableName] = 0
+
+	mock.ExpectClose()
+
+	deletedRows, err := cleaner.PerformCleanupAllInDB(connection, maxAge, false)
+	assert.Error(t, err, "error expected while calling tested function")
+
+	// check tables have correct number of deleted rows for each table
+	for tableName, deletedRowCount := range deletedRows {
+		assert.Equal(t, expectedResult[tableName], deletedRowCount)
+	}
+
+	// check if DB can be closed successfully
+	checkConnectionClose(t, connection)
+
+	// check all DB expectactions happened correctly
+	checkAllExpectations(t, mock)
+}
+
 // TestPerformCleanupAllInDBNoConnection checks the basic behaviour of
 // performCleanupAllInDB function when connection is not established.
 func TestPerformCleanupAllInDBNoConnection(t *testing.T) {
 	// connection that is not constructed correctly
 	var connection *sql.DB
 
-	_, err := cleaner.PerformCleanupAllInDB(connection, cleaner.DBSchemaOCPRecommendations, maxAge, false)
+	_, err := cleaner.PerformCleanupAllInDB(connection, maxAge, false)
 
 	assert.Error(t, err, "error is expected while calling tested function")
 }


### PR DESCRIPTION
# Description

Ignore the schema when running `-cleanup-all` so that we don't need 2 cronjobs.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

UTs

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
