### PR TITLE
Separate rule_hit cleanup into two separate queries to accelerate it

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -62,6 +62,9 @@ const (
 	maxAgeMissing                     = "max-age parameter is missing"
 	invalidSchemaMsg                  = "Invalid DB schema to be cleaned up: '%s'"
 	affectedMsg                       = "Affected"
+	dryRunMsg                         = "Dry run"
+	unableToDeleteRecords             = "Unable to delete records"
+	recordsDeletedMsg                 = "Delete records"
 )
 
 // Other messages
@@ -113,11 +116,13 @@ const (
 		 WHERE (cluster_id, org_id) IN (
 			SELECT cluster, org_id
 			FROM report
-			WHERE reported_at < NOW() - $1::INTERVAL)
-		 OR (cluster_id, org_id) NOT IN (
-		    SELECT cluster, org_id
-			FROM report
-		 )`
+			WHERE reported_at < NOW() - $1::INTERVAL)`
+
+	deleteOrphanOCPRuleHits = `
+		DELETE FROM rule_hit
+		 WHERE (cluster_id, org_id) NOT IN (
+			SELECT cluster, org_id
+			FROM report)`
 
 	deleteOldOCPRecommendation = `
 		DELETE FROM recommendation
@@ -711,13 +716,18 @@ var (
 	allTablesToDelete = append(tablesToDeleteOCP, tablesToDeleteDVO...)
 )
 
+var tablesToDeleteOrphanOCP = []TableAndDeleteStatement{
+	{
+		TableName:       "rule_hit",
+		DeleteStatement: deleteOrphanOCPRuleHits,
+	},
+}
+
 // deleteOldRecordsFromTable function deletes old records from database
 // each delete query must have just one parameter that will be populated with
 // the maxAge value
 func deleteOldRecordsFromTable(connection *sql.DB, sqlStatement, maxAge string, dryRun bool) (int, error) {
-	if dryRun {
-		sqlStatement = strings.Replace(sqlStatement, "DELETE", "SELECT", -1)
-	}
+	sqlStatement = dryRunQuerySelector(sqlStatement, dryRun)
 	result, err := connection.Exec(sqlStatement, maxAge)
 	if err != nil {
 		return 0, err
@@ -729,6 +739,31 @@ func deleteOldRecordsFromTable(connection *sql.DB, sqlStatement, maxAge string, 
 		return 0, err
 	}
 	return int(affected), nil
+}
+
+// deleteOrphanRecordsFromTable function deletes old records from database
+func deleteOrphanRecordsFromTable(connection *sql.DB, sqlStatement string, dryRun bool) (int, error) {
+	sqlStatement = dryRunQuerySelector(sqlStatement, dryRun)
+	result, err := connection.Exec(sqlStatement)
+	if err != nil {
+		return 0, err
+	}
+
+	// read number of affected (deleted) rows
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
+}
+
+// dryRunQuerySelector function switches between DELETE and SELECT if needed when dry_run is true
+func dryRunQuerySelector(sqlStatement string, dryRun bool) string {
+	if dryRun {
+		sqlStatement = strings.Replace(sqlStatement, "DELETE", "SELECT", -1)
+	}
+
+	return sqlStatement
 }
 
 // tablesAndKeysInOCPDatabase contains list of all tables together with keys used to select
@@ -868,16 +903,35 @@ func performCleanupAllInDB(connection *sql.DB, maxAge string, dryRun bool) (
 			log.Error().
 				Err(err).
 				Str(tableName, tableAndDeleteStatement.TableName).
-				Msg("Unable to delete records")
+				Msg(unableToDeleteRecords)
 			return deletionsForTable, err
 		}
 		log.Info().
 			Int(affectedMsg, affected).
 			Str(tableName, tableAndDeleteStatement.TableName).
-			Bool("Dry run", dryRun).
-			Msg("Delete records")
+			Bool(dryRunMsg, dryRun).
+			Msg(recordsDeletedMsg)
 		deletionsForTable[tableAndDeleteStatement.TableName] = affected
 	}
+
+	log.Info().Msg("Cleanen orphaned nodes")
+	for _, tableAndDeleteStatement := range tablesToDeleteOrphanOCP {
+		affected, err := deleteOrphanRecordsFromTable(connection, tableAndDeleteStatement.DeleteStatement, dryRun)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str(tableName, tableAndDeleteStatement.TableName).
+				Msg(unableToDeleteRecords)
+			return deletionsForTable, err
+		}
+
+		log.Info().
+			Int(affectedMsg, affected).
+			Str(tableName, tableAndDeleteStatement.TableName).
+			Bool(dryRunMsg, dryRun).
+			Msg(recordsDeletedMsg)
+	}
+
 	log.Info().Msg("Cleanup-all finished")
 	return deletionsForTable, nil
 }


### PR DESCRIPTION
This reverts commit 7376d64438974b397504eca0cbf47806b6675be3.

# Description

The refactored query is way slower than one would expect. Let's try removing the `OR` to have quickest to execute queries.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
