### PR TITLE
Use WHERE EXISTS instead of USING for lib/pq

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -118,10 +118,13 @@ const (
 				WHERE report.reported_at < NOW() - $1::INTERVAL OR report.cluster IS NULL
 		)
 		DELETE FROM rule_hit
-			USING to_delete
-			WHERE
-				rule_hit.cluster_id = to_delete.cluster_id
-				AND rule_hit.org_id = to_delete.org_id`
+		WHERE EXISTS (
+			SELECT 1
+			FROM to_delete
+			WHERE rule_hit.cluster_id = to_delete.cluster_id
+				AND rule_hit.org_id = to_delete.org_id
+		)`
+
 	deleteOldOCPRecommendation = `
 		DELETE FROM recommendation
 		 WHERE created_at < NOW() - $1::INTERVAL`


### PR DESCRIPTION
# Description

Running the cleaner locally might fail due to the `USING` clause depending on version of `lib/pq`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
