### PR TITLE
Use last_checked_at column for dvo.report table cleanup

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -131,7 +131,7 @@ const (
 
 	deleteOldDVOReports = `
 		DELETE FROM dvo.dvo_report
-		 WHERE reported_at < NOW() - $1::INTERVAL`
+		 WHERE last_checked_at < NOW() - $1::INTERVAL`
 )
 
 // DB schemas


### PR DESCRIPTION
# Description

Use `last_checked_at` to identify DVO reports' age, as `reported_at` maintains its original value even if the row was updated.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
