### PR TITLE
Run the cleaner once per day at 12PM

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -69,7 +69,7 @@ parameters:
   value: "false"
 - name: JOB_SCHEDULE
   description: When the cronjob runs
-  value: "1 */1 * * *"
+  value: "0 12 * * *"
 - name: CPU_LIMIT
   description: Cpu limit of service
   value: 500m


### PR DESCRIPTION
# Description

Run the cleaner once per day a 12 PM (during working hours) instead of once per hour.

Fixes CCXDEV-12953

## Type of change

- Configuration update

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
