### PR TITLE
Add rbac dependency in Clowdapp for Konflux PR check

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -15,6 +15,7 @@ objects:
       iqePlugin: ccx
     dependencies:
       - ccx-insights-results
+      - rbac  # required by iqe-ccx-plugin in Konflux env.
     jobs:
       - name: cleaner
         schedule: ${JOB_SCHEDULE}


### PR DESCRIPTION
# Description

Workaround to get Konflux integration tests to run properly. RN it fails [due to missing RBAC](https://console.redhat.com/application-pipeline/workspaces/obsint-processing/applications/insights-results-aggregator-cleaner/pipelineruns/insights-results-aggregator-cleaner-68xfr-bvxlw).

## Type of change

- Configuration update

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
