### PR TITLE
Setting errcheck to version 1.8.0

### DIFF
--- a/goerrcheck.sh
+++ b/goerrcheck.sh
@@ -25,7 +25,7 @@ echo -e "${BLUE}Finding all unchecked errors${NC}"
 if ! [ -x "$(command -v errcheck)" ]
 then
     echo -e "${BLUE}Installing errcheck ${NC}"
-    GO111MODULE=on go install github.com/kisielk/errcheck@latest
+    GO111MODULE=on go install github.com/kisielk/errcheck@v1.8.0
 fi
 
 


### PR DESCRIPTION
…go version

# Description
Changing version of errcheck in pr checks from latest to 1.8.0 as in the newest update support for used version was removed. This change will unblock konflux update needed to be merged before Tuesday. https://github.com/RedHatInsights/insights-results-aggregator-cleaner/actions/runs/14126798746/job/39579391060?pr=405

Fixes # (issue)

## Type of change


## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
