### PR TITLE
[CCXDEV-16245] Switch to shared gotests reusable workflow

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -6,24 +6,12 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   gotests:
-    runs-on: ubuntu-latest
-    name: Go tests
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.25"
-      - name: Print env vars
-        run: env
-      - name: Unit tests
-        run: make test
-      - name: Check code coverage
-        run: ./check_coverage.sh
-      - name: Display code coverage
-        run: make coverage
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: RedHatInsights/processing-tools/.github/workflows/gotests.yaml@master
+    with:
+      coverage_threshold: 80
+    secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: golangci-lint-full
 
   - repo: https://github.com/RedHatInsights/processing-tools
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
       - id: abcgo
         args: ['--threshold=75']


### PR DESCRIPTION
# Description

- Replace inline `gotests.yaml` with reusable workflow from processing-tools
- Coverage threshold preserved at 80%

Fixes CCXDEV-16245

## Type of change

- Configuration update